### PR TITLE
バージョンの修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_from:
 AllCops:
   SuggestExtensions: false
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Exclude:
     - bin/**/*
     - config/*

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   class << self
     def digest(string)
       cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
-      BCrypt::Password.create(string, cost: cost)
+      BCrypt::Password.create(string, cost:)
     end
 
     ## ランダムなトークンを生成
@@ -42,7 +42,7 @@ inverse_of: :followed
   before_save :downcase_email # メールアドレスを事前に小文字に直す
   before_create :create_activation_digest
   # 括弧で括ったりもできるっぽい
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates(:name, presence: true, length: { minimum: 0, maximum: 50 })
 
   validates :email,
@@ -147,7 +147,7 @@ inverse_of: :followed
     ## distinctで重複項目の削除
     Micropost
       .left_outer_joins(user: :followers)
-      .where(part_of_feed, { id: id })
+      .where(part_of_feed, { id: })
       .distinct
       .includes(:user, image_attachment: :blob)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/microposts_spec.rb
+++ b/spec/requests/microposts_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Microposts' do
 
       it 'allows to create micropost on valid submission' do
         content = 'This micropost really ties the room together'
-        expect { post microposts_path, params: { micropost: { content: content } } }.to change(Micropost, :count).by(1)
+        expect { post microposts_path, params: { micropost: { content: } } }.to change(Micropost, :count).by(1)
         expect(response).to redirect_to root_url
         follow_redirect!
         expect(response.body).to include content

--- a/spec/requests/users/edit_spec.rb
+++ b/spec/requests/users/edit_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'UsersEdit' do
           name = 'Foo Bar'
           email = 'foo@bar.com'
 
-          patch user_path(user), params: { user: { name: name, email: email, password: '', password_confirmation: '' } }
+          patch user_path(user), params: { user: { name:, email:, password: '', password_confirmation: '' } }
 
           expect(flash.empty?).not_to be true
           expect(response).to redirect_to user

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,7 +9,7 @@ Capybara.register_driver :chrome_headless do |app|
   options.add_argument('--disable-dev-shm-usage')
   options.add_argument('--window-size=1400,1400')
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 
 Capybara.javascript_driver = :chrome_headless

--- a/spec/support/sessions_support.rb
+++ b/spec/support/sessions_support.rb
@@ -15,7 +15,7 @@ module SessionsSupport
 
   # テストユーザとしてログインする
   def log_in_as(user, password: 'password', remember_me: '1')
-    post login_path, params: { session: { email: user.email, password: password, remember_me: remember_me } }
+    post login_path, params: { session: { email: user.email, password:, remember_me: } }
   end
 
   # 実行前にリクエストを発行してないと失敗する！


### PR DESCRIPTION
## やったこと
使用しているrubyのバージョンとrubocopのrubyバージョンが違ったので修正した
- `TargetRubyVersion: 2.7`を`TargetRubyVersion: 3.2`に変更
- rubocop -A による自動修正

自動修正された箇所
- user: userのような書き方をしている部分をuser:と省略してかけるようになる部分)
- freezeメソッドの削除
   Ruby 3.0 から`# frozen-string-literal: true`で定数文字列がimmutableになる
