### PR TITLE
トークン生成APIのテストを作成

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -15,8 +15,6 @@ class AccessToken
   # @param email [String]
   # @return [self]
   def initialize(email:)
-    raise '入力している文字列が空か正しくありません' unless Regexp.new(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i).match?(email)
-
     @email = email
   end
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -15,6 +15,8 @@ class AccessToken
   # @param email [String]
   # @return [self]
   def initialize(email:)
+    raise '入力している文字列が空か正しくありません' unless Regexp.new(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i).match?(email)
+
     @email = email
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     password_confirmation { 'password' }
     activated { true }
     activated_at { Time.zone.now }
+    admin { [true, false].sample }
 
     trait :admin do
       admin { true }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,9 +6,12 @@ FactoryBot.define do
     sequence(:email) { |n| "test#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }
-    admin { true }
     activated { true }
     activated_at { Time.zone.now }
+
+    trait :admin do
+      admin { true }
+    end
 
     trait :noadmin do
       admin { false }

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -5,13 +5,27 @@ require 'rails_helper'
 RSpec.describe 'AccessToken' do
   let(:email) { 'example@test.com' }
   let(:access_token) { AccessToken.new(email:).encode }
+  let(:invalid_access_token) do
+    issued_at = 11.hours.ago
+    expired_at = issued_at + 1.hour
+    payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }
+    JWT.encode payload, Rails.application.credentials.app.secret_access_key, 'HS256'
+  end
 
   describe '#from_token' do
-    subject { AccessToken.from_token(access_token) }
-
     context 'トークンが正しい場合' do
-      it 'EmailがPayloadに入っている' do
+      subject { AccessToken.from_token(access_token) }
+
+      it 'デコードしてemailが読みとれる' do
         expect(subject.email).to eq email
+      end
+    end
+
+    context 'トークンが期限切れの場合' do
+      subject { AccessToken.from_token(invalid_access_token) }
+
+      it 'デコードに失敗する' do
+        expect(subject).to raise_error(JWT::ExpiredSignature, 'Signature has expired')
       end
     end
   end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AccessToken' do
+  describe '#encode' do
+  end
+
+  describe '#from_token' do
+    it '生成したアクセストークンが正しくデコードできること' do
+      email = 'uouo@uouo.com'
+      access_token = AccessToken.new(email:).encode
+      token = AccessToken.from_token(access_token)
+      expect(token.email).to eq email
+    end
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -3,18 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'AccessToken' do
-  let(:email) { 'example@test.com' }
-  let(:access_token) { AccessToken.new(email:).encode }
-  let(:expired_access_token) do
-    issued_at = 11.hours.ago
-    expired_at = issued_at + 1.hour
-    payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }
-    JWT.encode payload, Rails.application.credentials.app.secret_access_key, 'HS256'
-  end
-
   describe '#from_token' do
     context 'アクセストークンが正しい場合' do
       subject { AccessToken.from_token(access_token) }
+
+      let(:email) { 'example@test.com' }
+      let(:access_token) { AccessToken.new(email:).encode }
 
       it 'デコードしてemailが読みとれる' do
         expect(subject.email).to eq email
@@ -24,6 +18,13 @@ RSpec.describe 'AccessToken' do
     context 'アクセストークンが期限切れの場合' do
       subject { AccessToken.from_token(expired_access_token) }
 
+      let(:expired_access_token) do
+        issued_at = 11.hours.ago
+        expired_at = issued_at + 1.hour
+        payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }
+        JWT.encode payload, Rails.application.credentials.app.secret_access_key, 'HS256'
+      end
+
       it 'アクセストークンのデコードに失敗する' do
         expect { subject }.to raise_error(JWT::ExpiredSignature, 'Signature has expired')
       end
@@ -32,6 +33,8 @@ RSpec.describe 'AccessToken' do
 
   describe '#encode' do
     context 'アクセストークンが正しくエンコードできる場合' do
+      let(:email) { 'example@test.com' }
+      let(:access_token) { AccessToken.new(email:).encode }
       let(:header) { JSON.parse(Base64.decode64(access_token.split('.')[0]), symbolize_names: true) }
       let(:payload) { JSON.parse(Base64.decode64(access_token.split('.')[1]), symbolize_names: true) }
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'AccessToken' do
   end
 
   describe '#from_token' do
-    context 'トークンが正しい場合' do
+    context 'アクセストークンが正しい場合' do
       subject { AccessToken.from_token(access_token) }
 
       it 'デコードしてemailが読みとれる' do
@@ -21,17 +21,17 @@ RSpec.describe 'AccessToken' do
       end
     end
 
-    context 'トークンが期限切れの場合' do
+    context 'アクセストークンが期限切れの場合' do
       subject { AccessToken.from_token(expired_access_token) }
 
-      it 'デコードに失敗する' do
+      it 'アクセストークンのデコードに失敗する' do
         expect { subject }.to raise_error(JWT::ExpiredSignature, 'Signature has expired')
       end
     end
   end
 
   describe '#encode' do
-    context 'トークンが正しくエンコードできる場合' do
+    context 'アクセストークンが正しくエンコードできる場合' do
       let(:header) { JSON.parse(Base64.decode64(access_token.split('.')[0]), symbolize_names: true) }
       let(:payload) { JSON.parse(Base64.decode64(access_token.split('.')[1]), symbolize_names: true) }
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -3,15 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'AccessToken' do
-  describe '#encode' do
-  end
+  let(:email) { 'example@test.com' }
+  let(:access_token) { AccessToken.new(email:).encode }
 
   describe '#from_token' do
-    it '生成したアクセストークンが正しくデコードできること' do
-      email = 'uouo@uouo.com'
-      access_token = AccessToken.new(email:).encode
-      token = AccessToken.from_token(access_token)
-      expect(token.email).to eq email
+    subject { AccessToken.from_token(access_token) }
+
+    context 'トークンが正しい場合' do
+      it 'EmailがPayloadに入っている' do
+        expect(subject.email).to eq email
+      end
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -32,23 +32,21 @@ RSpec.describe 'AccessToken' do
   end
 
   describe '#encode' do
-    context 'アクセストークンが正しくエンコードできる場合' do
-      let(:email) { 'example@test.com' }
-      let(:access_token) { AccessToken.new(email:).encode }
-      let(:header) { JSON.parse(Base64.decode64(access_token.split('.')[0]), symbolize_names: true) }
-      let(:payload) { JSON.parse(Base64.decode64(access_token.split('.')[1]), symbolize_names: true) }
+    let(:email) { 'example@test.com' }
+    let(:access_token) { AccessToken.new(email:).encode }
+    let(:header) { JSON.parse(Base64.decode64(access_token.split('.')[0]), symbolize_names: true) }
+    let(:payload) { JSON.parse(Base64.decode64(access_token.split('.')[1]), symbolize_names: true) }
 
-      it 'アルゴリズムにHS256が設定してある' do
-        expect(header[:alg]).to eq 'HS256'
-      end
+    it 'アルゴリズムにHS256が設定してある' do
+      expect(header[:alg]).to eq 'HS256'
+    end
 
-      it 'subにemailが設定されている' do
-        expect(payload[:sub]).to eq email
-      end
+    it 'subにemailが設定されている' do
+      expect(payload[:sub]).to eq email
+    end
 
-      it '有効期限が1時間である' do
-        expect(payload[:exp] - payload[:iat]).to eq 1.hour.to_i
-      end
+    it '有効期限が1時間である' do
+      expect(payload[:exp] - payload[:iat]).to eq 1.hour.to_i
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -50,17 +50,5 @@ RSpec.describe 'AccessToken' do
         expect(payload[:exp] - payload[:iat]).to eq 1.hour.to_i
       end
     end
-
-    context 'emailアドレスが空の場合' do
-      it 'RuntimeErrorが出て失敗する' do
-        expect { AccessToken.new(email: '').encode }.to raise_error(RuntimeError)
-      end
-    end
-
-    context 'emailアドレスの形式が間違っている場合' do
-      it 'RuntimeErrorが出て失敗する' do
-        expect { AccessToken.new(email: 'hogehoge').encode }.to raise_error(RuntimeError)
-      end
-    end
   end
 end

--- a/spec/requests/api/token_spec.rb
+++ b/spec/requests/api/token_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'ApiToken' do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :admin) }
   let(:noadmin) { create(:user, :noadmin) }
 
   # Token生成のAPIのテスト

--- a/spec/requests/api/token_spec.rb
+++ b/spec/requests/api/token_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ApiToken' do
+  let(:user) { create(:user) }
+  let(:noadmin) { create(:user, :noadmin) }
+
+  # Token生成のAPIのテスト
+
+  describe 'POST /api/token' do
+    context 'ユーザが存在する場合' do
+      context 'ユーザがadminの場合' do
+        it '200が返って、アクセストークンを返すこと' do
+          post '/api/token', params: { email: user.email, password: user.password }
+          expect(response).to be_successful
+          expect(response.parsed_body).to have_key('access_token')
+        end
+      end
+
+      context 'ユーザがAdminでない場合' do
+        it '403が返って、エラーメッセージを返すこと' do
+          post '/api/token', params: { email: noadmin.email, password: noadmin.password }
+          expect(response).to have_http_status :forbidden
+          expect(response.body.parsed_body).to have_key(:message)
+        end
+      end
+    end
+
+    context 'ユーザが存在しない場合' do
+      it '401が返って、エラーメッセージを返すこと' do
+        post '/api/token', params: { email: 'test@hogehgoe.com', password: 'invalid password' }
+        expect(response).to have_http_status :unauthorized
+        expect(response.body.parsed_body).to have_key(:message)
+      end
+    end
+  end
+end

--- a/spec/requests/api/token_spec.rb
+++ b/spec/requests/api/token_spec.rb
@@ -3,14 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'ApiToken' do
-  let(:user) { create(:user, :admin) }
-  let(:noadmin) { create(:user, :noadmin) }
-
-  # Token生成のAPIのテスト
-
   describe 'POST /api/token' do
     context 'ユーザが存在する場合' do
       context 'ユーザがadminの場合' do
+        let(:user) { create(:user, :admin) }
+
         it '200が返って、アクセストークンを返すこと' do
           post '/api/token', params: { email: user.email, password: user.password }
           expect(response).to be_successful
@@ -19,6 +16,8 @@ RSpec.describe 'ApiToken' do
       end
 
       context 'ユーザがAdminでない場合' do
+        let(:noadmin) { create(:user, :noadmin) }
+
         it '403が返って、エラーメッセージを返すこと' do
           post '/api/token', params: { email: noadmin.email, password: noadmin.password }
           expect(response).to have_http_status :forbidden

--- a/spec/requests/api/token_spec.rb
+++ b/spec/requests/api/token_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ApiToken' do
         it '403が返って、エラーメッセージを返すこと' do
           post '/api/token', params: { email: noadmin.email, password: noadmin.password }
           expect(response).to have_http_status :forbidden
-          expect(response.body.parsed_body).to have_key(:message)
+          expect(response.parsed_body).to have_key('message')
         end
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe 'ApiToken' do
       it '401が返って、エラーメッセージを返すこと' do
         post '/api/token', params: { email: 'test@hogehgoe.com', password: 'invalid password' }
         expect(response).to have_http_status :unauthorized
-        expect(response.body.parsed_body).to have_key(:message)
+        expect(response.parsed_body).to have_key('message')
       end
     end
   end

--- a/spec/requests/users/index_spec.rb
+++ b/spec/requests/users/index_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Index' do
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user, :admin) }
   let!(:noadmin) { create(:user, :noadmin) }
   let!(:noactivated) { create(:user, :noactivated) }
   let!(:user_list) { create_list(:user, 50, :noadmin) }


### PR DESCRIPTION
## やったこと
- APIのテストを作成
- jwtの検証をするテストを作成

###  spec/requests/api/token_spec.rbに次の3通りのテストを作成した。
- '正しいログイン情報の場合'  : 200でアクセストークンがレスポンスとして返ってくる
- '正しいログイン情報だが、Adminでない場合' : 403で'Access denied. You are not admin user'というメッセージが入っている
- '不明なログイン情報の場合' : 401で'Unauthorized. Make sure you have the parameters.'というメッセージが入っている

### spec/utils/token_util_spec.rbにtokenを検証するためのテストを作成した
jwtエンコードしたものをデコードし直して次の2点を検証した
- payloadに正しいemailとexpが入っているか
- headerのalgは`HS256`になっているか