### PR TITLE
Supportにメソッドを切り出し

### DIFF
--- a/api/users/show.md
+++ b/api/users/show.md
@@ -6,8 +6,7 @@
 
 http://localhost:3000/api/users/:id
 
-トークンが無効の場合は 401<br>
-トークンがない時は 403<br>
+トークンが無効の場合、トークンがない時は 401<br>
 
 ## Header
 
@@ -63,8 +62,18 @@ Content-Type: `application/json`
 
 ### 401
 
-invalid token
+- アクセストークンが無効な場合
 
-### 403
+```json
+{
+  "message": "Unauthorized. Invalid token"
+}
+```
 
-Missing authentication token
+- アクセストークンがない場合
+
+```json
+{
+  "message": "Unauthorized. Missing authentication token"
+}
+```

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe 'AccessToken' do
     context 'アクセストークンが期限切れの場合' do
       subject { AccessToken.from_token(expired_access_token) }
 
-      let(:email) { 'example@test.com' }
-      let(:expired_access_token) do
-        issued_at = 11.hours.ago
-        expired_at = issued_at + 1.hour
-        payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }
-        JWT.encode payload, Rails.application.credentials.app.secret_access_key, 'HS256'
-      end
-
       it 'アクセストークンのデコードに失敗する' do
         expect { subject }.to raise_error(JWT::ExpiredSignature, 'Signature has expired')
       end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'AccessToken' do
+  let(:email) { 'example@test.com' }
+
   describe '#from_token' do
     context 'アクセストークンが正しい場合' do
       subject { AccessToken.from_token(access_token) }
 
-      let(:email) { 'example@test.com' }
       let(:access_token) { AccessToken.new(email:).encode }
 
       it 'デコードしてemailが読みとれる' do
@@ -16,7 +17,7 @@ RSpec.describe 'AccessToken' do
     end
 
     context 'アクセストークンが期限切れの場合' do
-      subject { AccessToken.from_token(expired_access_token) }
+      subject { AccessToken.from_token(expired_access_token(email:)) }
 
       it 'アクセストークンのデコードに失敗する' do
         expect { subject }.to raise_error(JWT::ExpiredSignature, 'Signature has expired')
@@ -25,7 +26,6 @@ RSpec.describe 'AccessToken' do
   end
 
   describe '#encode' do
-    let(:email) { 'example@test.com' }
     let(:access_token) { AccessToken.new(email:).encode }
     let(:header) { JSON.parse(Base64.decode64(access_token.split('.')[0]), symbolize_names: true) }
     let(:payload) { JSON.parse(Base64.decode64(access_token.split('.')[1]), symbolize_names: true) }

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ApiToken' do
+RSpec.describe 'ApiTokens' do
   describe 'POST /api/token' do
     context 'ユーザが存在する場合' do
       context 'ユーザがadminの場合' do

--- a/spec/support/access_token_support.rb
+++ b/spec/support/access_token_support.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module AccessTokenSupport
-  def expired_access_token
-    email = 'test@example.com'
+  def expired_access_token(email:)
     issued_at = 11.hours.ago
     expired_at = issued_at + 1.hour
     payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }

--- a/spec/support/access_token_support.rb
+++ b/spec/support/access_token_support.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AccessTokenSupport
+  def expired_access_token
+    email = 'test@example.com'
+    issued_at = 11.hours.ago
+    expired_at = issued_at + 1.hour
+    payload = { sub: email, iat: issued_at.to_i, exp: expired_at.to_i }
+    JWT.encode payload, Rails.application.credentials.app.secret_access_key, 'HS256'
+  end
+end
+RSpec.configure { |config| config.include AccessTokenSupport }


### PR DESCRIPTION
## やったこと
- 期限切れのアクセストークンを作成するコードを次のユーザ表示を行うプログラムでも利用するためにsupportに関数として分離した
- tokens_controllerのspecなのでtoken_specからtokens_specに名前を変更した