### PR TITLE
指定IDのユーザを返すAPIの作成

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,3 +48,7 @@ Rails/I18nLocaleTexts:
 # 冗長なpresenceを消す設定
 Rails/RedundantPresenceValidationOnBelongsTo:
   Enabled: false
+
+RSpec/ImplicitSubject:
+  Enabled: true
+  EnforcedStyle: single_statement_only

--- a/api/users/show.md
+++ b/api/users/show.md
@@ -77,3 +77,13 @@ Content-Type: `application/json`
   "message": "Unauthorized. Missing authentication token"
 }
 ```
+
+### 500
+
+サーバー側で予期しないエラーが発生した場合
+
+```json
+{
+  "message": "Internal Server Error"
+}
+```

--- a/api/users/show.md
+++ b/api/users/show.md
@@ -85,13 +85,3 @@ Content-Type: `application/json`
   "message": "Not Found. User with this ID does not exist"
 }
 ```
-
-### 500
-
-サーバー側で予期しないエラーが発生した場合
-
-```json
-{
-  "message": "Internal Server Error"
-}
-```

--- a/api/users/show.md
+++ b/api/users/show.md
@@ -82,6 +82,6 @@ Content-Type: `application/json`
 
 ```json
 {
-  "message": "Not Found. User with this ID does not exist"
+  "message": "Not Found. User does not exist"
 }
 ```

--- a/api/users/show.md
+++ b/api/users/show.md
@@ -6,8 +6,6 @@
 
 http://localhost:3000/api/users/:id
 
-トークンが無効の場合、トークンがない時は 401<br>
-
 ## Header
 
 ```yml
@@ -75,6 +73,16 @@ Content-Type: `application/json`
 ```json
 {
   "message": "Unauthorized. Missing authentication token"
+}
+```
+
+### 404
+
+存在しない ID を指定した場合
+
+```json
+{
+  "message": "Not Found. User with this ID does not exist"
 }
 ```
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -8,11 +8,11 @@ module Api
     protected
 
     def authenticate
-      token = request.headers['Authorization']
-      return render json: { message: 'Missing authentication token' }, status: :unauthorized if token.nil?
+      access_token = request.headers['Authorization']
+      return render json: { message: 'Missing authentication token' }, status: :unauthorized if access_token.nil?
 
       begin
-        AccessToken.from_token(token[7..])
+        AccessToken.from_token(access_token[7..])
       rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError
         render json: { message: 'Unauthorized. Invalid token' }, status: :unauthorized
       end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,11 +13,8 @@ module Api
 
       begin
         AccessToken.from_token(access_token[7..])
-      rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError
+      rescue JWT::DecodeError
         render json: { message: 'Unauthorized. Invalid token' }, status: :unauthorized
-      rescue StandardError
-        render json: { message: 'Internal Server Error' }, status: :internal_server_error
-      end
     end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -15,6 +15,8 @@ module Api
         AccessToken.from_token(access_token[7..])
       rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError
         render json: { message: 'Unauthorized. Invalid token' }, status: :unauthorized
+      rescue StandardError
+        render json: { message: 'Internal Server Error' }, status: :internal_server_error
       end
     end
   end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,11 +3,11 @@
 module Api
   class ApiController < ActionController::API
     include ActionController::HttpAuthentication::Token::ControllerMethods
-    before_action :authenticate
+    before_action :require_access_token
 
     protected
 
-    def authenticate
+    def require_access_token
       access_token = request.headers['Authorization']
       return render json: { message: 'Missing authentication token' }, status: :unauthorized if access_token.nil?
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  class ApiController < ActionController::API
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+    before_action :authenticate
+
+    protected
+
+    def authenticate
+      token = request.headers['Authorization']
+      return render json: { message: 'Missing authentication token' }, status: :unauthorized if token.nil?
+
+      begin
+        AccessToken.from_token(token[7..])
+      rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError
+        render json: { message: 'Unauthorized. Invalid token' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -15,6 +15,7 @@ module Api
         AccessToken.from_token(access_token[7..])
       rescue JWT::DecodeError
         render json: { message: 'Unauthorized. Invalid token' }, status: :unauthorized
+      end
     end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,12 +2,20 @@
 
 module Api
   class UsersController < ApiController
+    before_action :validate_user_id, only: %i[show]
     # GET /api/users/:id
     def show
-      user = User.find_by(id: params[:id])
-      return render_user_nil if user.nil?
+      render_user user
+    end
 
-      render json: {
+    private
+
+    def user
+      @_user ||= User.find_by(id: params[:id])
+    end
+
+    def render_user(user)
+      render status: :ok, json: {
         id:           user.id,
         name:         user.name,
         email:        user.email,
@@ -19,9 +27,9 @@ module Api
       }
     end
 
-    private
+    def validate_user_id
+      return if user.present?
 
-    def render_user_nil
       render status: :not_found,
              json:   { message: 'Not Found. User does not exist' }
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,11 +10,11 @@ module Api
         id:           user.id,
         name:         user.name,
         email:        user.email,
-        created_at:   user.created_at.iso8601(2),
-        updated_at:   user.updated_at.iso8601(2),
         admin:        user.admin,
         activated:    user.activated,
-        activated_at: user.activated_at.iso8601(2)
+        activated_at: user.activated_at.iso8601(2),
+        created_at:   user.created_at.iso8601(2),
+        updated_at:   user.updated_at.iso8601(2)
       }
     end
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,11 +2,10 @@
 
 module Api
   class UsersController < ApiController
-    before_action :validate_user_id
-
     # GET /api/users/:id
     def show
-      user = User.find(params[:id])
+      user = User.find_by(id: params[:id])
+      return render_user_nil if user.nil?
 
       render json: {
         id:           user.id,
@@ -22,11 +21,9 @@ module Api
 
     private
 
-    def validate_user_id
-      return if User.exists?(id: params[:id])
-
+    def render_user_nil
       render status: :not_found,
-             json:   { message: 'Not Found. User with this ID does not exist' }
+             json:   { message: 'Not Found. User does not exist' }
     end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  class UsersController < ApiController
+    # GET /api/users/:id
+    def show
+      render json: User.select(
+        :id,
+        :name,
+        :email,
+        :created_at,
+        :updated_at,
+        :admin,
+        :activated,
+        :activated_at
+      ).find(params[:id])
+    end
+  end
+end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -4,16 +4,18 @@ module Api
   class UsersController < ApiController
     # GET /api/users/:id
     def show
-      render json: User.select(
-        :id,
-        :name,
-        :email,
-        :created_at,
-        :updated_at,
-        :admin,
-        :activated,
-        :activated_at
-      ).find(params[:id])
+      user = User.find(params[:id])
+
+      render json: {
+        id:           user.id,
+        name:         user.name,
+        email:        user.email,
+        created_at:   user.created_at.iso8601(2),
+        updated_at:   user.updated_at.iso8601(2),
+        admin:        user.admin,
+        activated:    user.activated,
+        activated_at: user.activated_at.iso8601(2)
+      }
     end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class UsersController < ApiController
+    before_action :validate_user_id
+
     # GET /api/users/:id
     def show
       user = User.find(params[:id])
@@ -16,6 +18,15 @@ module Api
         created_at:   user.created_at.iso8601(2),
         updated_at:   user.updated_at.iso8601(2)
       }
+    end
+
+    private
+
+    def validate_user_id
+      return if User.exists?(id: params[:id])
+
+      render status: :not_found,
+             json:   { message: 'Not Found. User with this ID does not exist' }
     end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -22,18 +22,19 @@ RSpec.describe 'ApiUsers' do
 
       it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
         expect(subject).to be_successful
+        
         user_data = JSON.parse(subject.body, symbolize_names: true)
-        target_data = {
-          id:           target.id,
-          name:         target.name,
-          email:        target.email,
-          admin:        target.admin,
-          activated:    target.activated,
-          activated_at: target.activated_at.iso8601(2),
-          created_at:   target.created_at.iso8601(2),
-          updated_at:   target.updated_at.iso8601(2)
-        }
-        expect(user_data).to eq target_data
+        expect(user_data).to include(
+          {
+            id:           target.id,
+            name:         target.name,
+            admin:        target.admin,
+            activated:    target.activated,
+            activated_at: target.activated_at.iso8601(2),
+            created_at:   target.created_at.iso8601(2),
+            updated_at:   target.updated_at.iso8601(2)
+          }
+        )
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -5,6 +5,11 @@ require 'rails_helper'
 RSpec.describe 'ApiUsers' do
   describe 'GET /api/users/:id' do
     context 'アクセストークンが有効の場合' do
+      subject do
+        get("/api/users/#{target.id}", headers:)
+        response
+      end
+
       let(:user) { create(:user, :admin) }
       let(:target) { create(:user, :noadmin) }
       let(:access_token) { AccessToken.new(email: user.email).encode }
@@ -16,9 +21,8 @@ RSpec.describe 'ApiUsers' do
       end
 
       it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
-        get("/api/users/#{target.id}", headers:)
-        expect(response).to be_successful
-        user_data = JSON.parse(response.body, symbolize_names: true)
+        expect(subject).to be_successful
+        user_data = JSON.parse(subject.body, symbolize_names: true)
         target_data = {
           id:           target.id,
           name:         target.name,
@@ -34,6 +38,11 @@ RSpec.describe 'ApiUsers' do
     end
 
     context 'アクセストークンが有効期限切れの場合' do
+      subject do
+        get("/api/users/#{target.id}", headers:)
+        response
+      end
+
       let(:target) { create(:user, :noadmin) }
       let(:headers) do
         {
@@ -43,13 +52,17 @@ RSpec.describe 'ApiUsers' do
       end
 
       it '401でエラーメッセージを出力して失敗する' do
-        get("/api/users/#{target.id}", headers:)
-        expect(response).to be_unauthorized
-        expect(response.parsed_body).to have_key('message')
+        expect(subject).to be_unauthorized
+        expect(subject.parsed_body).to have_key('message')
       end
     end
 
     context 'アクセストークンがない場合' do
+      subject do
+        get("/api/users/#{target.id}", headers:)
+        response
+      end
+
       let(:target) { create(:user, :noadmin) }
       let(:headers) do
         {
@@ -59,8 +72,8 @@ RSpec.describe 'ApiUsers' do
 
       it '401でエラーメッセージを出力して失敗する' do
         get("/api/users/#{target.id}", headers:)
-        expect(response).to be_unauthorized
-        expect(response.parsed_body).to have_key('message')
+        expect(subject).to be_unauthorized
+        expect(subject.parsed_body).to have_key('message')
       end
     end
   end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ApiUsers' do
 
       it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
         expect(subject).to be_successful
-        
+
         user_data = JSON.parse(subject.body, symbolize_names: true)
         expect(user_data).to include(
           {

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe 'ApiUsers' do
 
       it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
         expect(subject).to be_successful
-
-        user_data = JSON.parse(subject.body, symbolize_names: true)
-        expect(user_data).to include(
+        expect(subject.parsed_body.symbolize_keys).to include(
           {
             id:           target.id,
             name:         target.name,

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -4,18 +4,18 @@ require 'rails_helper'
 
 RSpec.describe 'ApiUsers' do
   describe 'GET /api/users/:id' do
-    context 'アクセストークンが有効の場合' do
-      subject do
-        get("/api/users/#{target.id}", headers:)
-        response
-      end
+    subject do
+      get("/api/users/#{target.id}", headers:)
+      response
+    end
 
+    let(:target) { create(:user, :noadmin) }
+
+    context 'アクセストークンが有効の場合' do
       let(:user) { create(:user, :admin) }
-      let(:target) { create(:user, :noadmin) }
       let(:access_token) { AccessToken.new(email: user.email).encode }
       let(:headers) do
         {
-          'Accept'        => 'application/json',
           'Authorization' => "Bearer #{access_token}"
         }
       end
@@ -38,15 +38,8 @@ RSpec.describe 'ApiUsers' do
     end
 
     context 'アクセストークンが有効期限切れの場合' do
-      subject do
-        get("/api/users/#{target.id}", headers:)
-        response
-      end
-
-      let(:target) { create(:user, :noadmin) }
       let(:headers) do
         {
-          'Accept'        => 'application/json',
           'Authorization' => "Bearer #{expired_access_token}"
         }
       end
@@ -58,20 +51,8 @@ RSpec.describe 'ApiUsers' do
     end
 
     context 'アクセストークンがない場合' do
-      subject do
-        get("/api/users/#{target.id}", headers:)
-        response
-      end
-
-      let(:target) { create(:user, :noadmin) }
-      let(:headers) do
-        {
-          'Accept' => 'application/json'
-        }
-      end
-
       it '401でエラーメッセージを出力して失敗する' do
-        get("/api/users/#{target.id}", headers:)
+        get("/api/users/#{target.id}")
         expect(subject).to be_unauthorized
         expect(subject.parsed_body).to have_key('message')
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -18,11 +18,22 @@ RSpec.describe 'ApiUsers' do
       it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
         get("/api/users/#{target.id}", headers:)
         expect(response).to be_successful
+        user_data = JSON.parse(response.body, symbolize_names: true)
+        target_data = {
+          id:           target.id,
+          name:         target.name,
+          email:        target.email,
+          created_at:   target.created_at.iso8601(2),
+          updated_at:   target.updated_at.iso8601(2),
+          admin:        target.admin,
+          activated:    target.activated,
+          activated_at: target.activated_at.iso8601(2)
+        }
+        expect(user_data).to eq target_data
       end
     end
 
     context 'アクセストークンが有効期限切れの場合' do
-      #   headers = { "ACCEPT" => "application/json" }
       let(:target) { create(:user, :noadmin) }
       let(:headers) do
         {

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ApiUsers' do
+  describe 'GET /api/users/:id' do
+    context 'アクセストークンが有効の場合' do
+      let(:user) { create(:user, :admin) }
+      let(:target) { create(:user, :noadmin) }
+      let(:access_token) { AccessToken.new(email: user.email).encode }
+      let(:headers) do
+        {
+          'Accept'        => 'application/json',
+          'Authorization' => "Bearer #{access_token}"
+        }
+      end
+
+      it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
+        get("/api/users/#{target.id}", headers:)
+        expect(response).to be_successful
+      end
+    end
+
+    context 'アクセストークンが有効期限切れの場合' do
+      #   headers = { "ACCEPT" => "application/json" }
+      let(:target) { create(:user, :noadmin) }
+      let(:headers) do
+        {
+          'Accept'        => 'application/json',
+          'Authorization' => "Bearer #{expired_access_token}"
+        }
+      end
+
+      it '401でエラーメッセージを出力して失敗する' do
+        get("/api/users/#{target.id}", headers:)
+        expect(response).to be_unauthorized
+        expect(response.parsed_body).to have_key('message')
+      end
+    end
+
+    context 'アクセストークンがない場合' do
+      let(:target) { create(:user, :noadmin) }
+      let(:headers) do
+        {
+          'Accept' => 'application/json'
+        }
+      end
+
+      it '401でエラーメッセージを出力して失敗する' do
+        get("/api/users/#{target.id}", headers:)
+        expect(response).to be_unauthorized
+        expect(response.parsed_body).to have_key('message')
+      end
+    end
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe 'ApiUsers' do
           id:           target.id,
           name:         target.name,
           email:        target.email,
-          created_at:   target.created_at.iso8601(2),
-          updated_at:   target.updated_at.iso8601(2),
           admin:        target.admin,
           activated:    target.activated,
-          activated_at: target.activated_at.iso8601(2)
+          activated_at: target.activated_at.iso8601(2),
+          created_at:   target.created_at.iso8601(2),
+          updated_at:   target.updated_at.iso8601(2)
         }
         expect(user_data).to eq target_data
       end


### PR DESCRIPTION
## やったこと
- 指定IDのユーザを返すAPIを作成
- 指定IDのユーザを返すAPIのテストを作成

### 1. 指定IDのユーザを返すAPIを作成
- トークンが間違っている時、トークンがない時に401を返す必要があるので`app/controllers/api/api_controller.rb`に親クラスを作成し、before_actionでヘッダー情報に問題のあるものを弾くようにした

### 2. 指定IDのユーザを返すAPIのテストの作成
以下の3通りでテストを作成した
- アクセストークンが有効の場合
- アクセストークンが有効期限切れの場合
- アクセストークンがない場合

## 気になっていることなど
- ActiveRecordを取得するときに今回であれば日付をすべてiso8601で取り出す方法があれば知りたい。
- アクセストークンが合っているかどうかを`from_token`メソッドが失敗するかしないかで判断しているが、verifyメソッドのようなものを作った方がわかりやすいだろうか？