### PR TITLE
ドキュメントの修正

### DIFF
--- a/api/users/show.md
+++ b/api/users/show.md
@@ -6,8 +6,7 @@
 
 http://localhost:3000/api/users/:id
 
-トークンが無効の場合は 401<br>
-トークンがない時は 403<br>
+トークンが無効の場合、トークンがない時は 401<br>
 
 ## Header
 
@@ -63,8 +62,18 @@ Content-Type: `application/json`
 
 ### 401
 
-invalid token
+- アクセストークンが無効な場合
 
-### 403
+```json
+{
+  "message": "Unauthorized. Invalid token"
+}
+```
 
-Missing authentication token
+- アクセストークンがない場合
+
+```json
+{
+  "message": "Unauthorized. Missing authentication token"
+}
+```


### PR DESCRIPTION
## やったこと

トークンがない時のレスポンスを403と設定していたが、403は認証は通るが、認可がない時に用いられるもので401が適切だと考えたので修正した。
レスポンスの形式もトークンの方と合わせてjsonで記述するように変更した