### PR TITLE
emailが追加されていなかったのを修正した

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -37,9 +37,10 @@ RSpec.describe 'ApiUsers' do
     end
 
     context 'アクセストークンが有効期限切れの場合' do
+      let(:email) { 'hogehoge@example.com' }
       let(:headers) do
         {
-          'Authorization' => "Bearer #{expired_access_token}"
+          'Authorization' => "Bearer #{expired_access_token(email:)}"
         }
       end
 


### PR DESCRIPTION
## やったこと

別のPRでexpired_access_tokenのメソッドの引数にemailを追加したことによってテストが通らなくなっていたのを修正した