### PR TITLE
エラーを確認するためのマッチャを作成した

### DIFF
--- a/spec/support/matchers/error_type.rb
+++ b/spec/support/matchers/error_type.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_error do |name, message|
+  match do |actual|
+    actual.parsed_body['errors'].include?({ 'name' => name, 'message' => message })
+  end
+end


### PR DESCRIPTION
## やったこと
ユーザ作成のAPIのテストで`User.create`に失敗した時のuser.errorsの中身を検証するマッチャを作成した

実行例: `expect(subject).to have_error 'name', 'is too long (maximum is 50 characters)'`

レスポンスのイメージ
```json
{
  "errors": [
    {"name": "email", "message": "invalid hoge"}, 
    {"name": "email", "message": "too long"}, 
    ...
  ]
}
```

## 気になっていること
- オブジェクトを含むかどうかで検証しているところがよくない気がする
`include?({ 'name' => name, 'message' => message })`
- messageまで検証しなくても良い気がしていること
- マッチャの書き方にはまだ不慣れなのでコメント欲しいです。

