### PR TITLE
ユーザ削除用のAPIの仕様書を作成した

### DIFF
--- a/api/users/destroy.md
+++ b/api/users/destroy.md
@@ -1,0 +1,86 @@
+# DELETE /api/users/:id
+
+ユーザの削除用 API
+
+## リソース URL
+
+http://localhost:3000/api/users/:id
+
+## Parameters
+
+| 名称 | 型      | 必須か   | 　説明    | 例    |
+| ---- | ------- | -------- | --------- | ----- |
+| id   | Integer | required | ユーザ ID | 11111 |
+
+## request
+
+```bash
+curl -X DELETE \
+  -H "Authorization: Bearer <YOUR-TOKEN>"\
+  http://localhost:3000/api/users/123
+```
+
+## Response
+
+### 204 No Content
+
+Nothing
+
+### 400 Bad Request
+
+- アクセストークンがない場合
+  ```json
+  {
+    "errors": [
+      {
+        "name": "access_token",
+        "message": "Bad Request. Missing authentication token"
+      }
+    ]
+  }
+  ```
+
+### 401 Unauthorized
+
+- アクセストークンが無効な場合
+
+  ```json
+  {
+    "errors": [
+      {
+        "token": "access_token",
+        "message": "Unauthorized. Invalid token"
+      }
+    ]
+  }
+  ```
+
+### 404 Not Found
+
+存在しない ID を指定した場合
+
+```json
+{
+  "errors": [
+    {
+      "name": "user_id",
+      "message": "Not Found. User does not exist"
+    }
+  ]
+}
+```
+
+### 422 Unprocessable Entity
+
+自分の ID を指定した場合
+
+```json
+{
+  "errors": [
+    {
+      "name": "user_id",
+      "message": "You can't delete yourself"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## やったこと

ユーザ削除用のAPIの仕様書を作成した
自分の ID を指定した場合は削除できないようにする

- 成功 : 204 No Content
- アクセストークンがない場合 : 400 Bad Request
- アクセストークンが無効な場合 : 401 Unauthorized
- 存在しない ID を指定した場合 : 404 Not Found
- 自分の ID を指定した場合 : 422 Unprocessable Entity


