### PR TITLE
RSpecのdebugを追加

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,16 @@
       "script": "s", // launch rails server with debugger
       "args": [],
       "askParameters": false // Do not ask startup parameter any more
+    },
+    {
+      "type": "rdbg",
+      "name": "Run rspec",
+      "rdbgPath": "bundle exec rdbg", // Use the debug.gem described in the Gemfile
+      "request": "launch",
+      "command": "bundle exec", // Breakpoints do not work with "rails".
+      "script": "rspec", // launch rails server with debugger
+      "args": [],
+      "askParameters": false
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,13 +16,24 @@
     },
     {
       "type": "rdbg",
-      "name": "Run rspec",
-      "rdbgPath": "bundle exec rdbg", // Use the debug.gem described in the Gemfile
+      "name": "rspec -all",
+      "rdbgPath": "bundle exec rdbg",
       "request": "launch",
-      "command": "bundle exec", // Breakpoints do not work with "rails".
-      "script": "rspec", // launch rails server with debugger
+      "command": "bundle exec",
+      "script": "rspec",
       "args": [],
-      "askParameters": false
+      "askParameters": false,
+      "useTerminal": true
+    },
+    {
+      "name": "rspec -current",
+      "type": "rdbg",
+      "request": "launch",
+      "command": "bundle exec rspec",
+      "script": "${file}",
+      "args": [],
+      "askParameters": true,
+      "useTerminal": true
     }
   ]
 }


### PR DESCRIPTION
## やりたかったこと
vscodeでdebug gemを使ってrspecのテストをすること

※ 動かなかったので意見が欲しいです(解決に時間を必要としそうだったので、一旦この質問のPRだけ投げて別タスクやっていきます)


## わかったこと
`bundle exec rdbg -c -- bundle exec rspec spec/requests/api/tokens_spec.rb `のように直接コマンドでdebugすればbinding.breakとかでデバック自体はできること。これはこれで便利だ。しかし、vscodeでできるようにしたい...

- `continue`で次のブレイクポイントまで進めれる
- ブレイクポイントは`binding.break`
- `info`で現在の変数などの状態を確認できる

```ruby
vscode ➜ /workspaces/rails-sample (modify-ci) $ bundle exec rdbg -c -- bundle exec rspec spec/requests/api/tokens_spec.rb 
[4, 13] in /usr/local/rvm/gems/default/bin/rspec
     4| #
     5| # The application 'rspec-core' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8| 
=>   9| require 'rubygems'
    11| Gem.use_gemdeps
    12| 
    13| version = ">= 0.a"
  #1    [C] Kernel.load at /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:58
  # and 14 frames (use `bt' command for all frames)
(rdbg) continue    # command
.[17, 26] in /workspaces/rails-sample/spec/requests/api/tokens_spec.rb
    17| 
    18|       context 'ユーザがAdminでない場合' do
    19|         let(:noadmin) { create(:user, :noadmin) }
    20| 
    21|         it '403が返って、エラーメッセージを返すこと' do
=>  22|           binding.break
    23|           post '/api/token', params: { email: noadmin.email, password: noadmin.password }
    24|           expect(response).to have_http_status :forbidden
    25|           expect(response.parsed_body).to have_key('message')
    26|         end
=>#0    block in <top (required)> (5 levels) at /workspaces/rails-sample/spec/requests/api/tokens_spec.rb:22
  #1    [C] BasicObject#instance_exec at /usr/local/rvm/gems/default/gems/rspec-core-3.12.2/lib/rspec/core/example.rb:263
  # and 58 frames (use `bt' command for all frames)
(rdbg) info    # command
%self = #<RSpec::ExampleGroups::ApiTokens::POSTApiToken::Nested::Admin_2 "403が返って、エラーメッセージを返すこと" (./spec/requests/api/tokens_spec.rb:21)>
@__inspect_output = "\"403が返って、エラーメッセージを返すこと\" (./spec/requests/api/tokens_spec.rb:21)"
@__memoized = #<RSpec::Core::MemoizedHelpers::ThreadsafeMemoized:0x0000ffff836015e8 @memoized={}, 
...
```
## わからなかったこと
[vscode-rdbg](https://github.com/ruby/vscode-rdbg)に書いてあるrails sと同様の方法で設定したが、rails sは動くが、rspecの場合は`Couldn't start debug session. The debuggee process exited with code 1`と出て失敗した。

コマンドラインでも`rails s`の両方の場合で実行できるのにsessionが開始しない理由とはなんなのか
https://github.com/sls-training/2023-rails-sample/blob/bc80f57253892058b17fb4ac5f089304bbf673f2/.vscode/launch.json#L5-L26