### PR TITLE
アクセストークンを発行したユーザを取得できるように変更

### DIFF
--- a/app/controllers/concerns/access_token_verifiable.rb
+++ b/app/controllers/concerns/access_token_verifiable.rb
@@ -7,6 +7,10 @@ module AccessTokenVerifiable
     before_action :verify_access_token_in_header
   end
 
+  def token_user
+    @_token_user
+  end
+
   def verify_access_token_in_header
     authorization_header = request.headers['Authorization']
     access_token = authorization_header&.match(/Bearer (?<token>.+)/)&.[](:token)
@@ -14,7 +18,8 @@ module AccessTokenVerifiable
     return render_missing_token if access_token.nil?
 
     begin
-      AccessToken.from_token(access_token)
+      email = AccessToken.from_token(access_token).email
+      @_token_user = User.find_by(email:)
     rescue JWT::DecodeError
       render_invalid_token
     end

--- a/app/controllers/concerns/access_token_verifiable.rb
+++ b/app/controllers/concerns/access_token_verifiable.rb
@@ -16,7 +16,7 @@ module AccessTokenVerifiable
   end
 
   def current_user
-    @_current_user ||= User.find_by(email: access_token.email)
+    @_current_user ||= User.find_by(email: access_token&.email)
   end
 
   def verify_access_token_in_header


### PR DESCRIPTION
## やったこと

トークンを発行したユーザ情報を保持してコントローラで参照できるように変更した

理由: 次に実装するユーザ削除APIでユーザが自分自身の時は削除できないという仕様になっているため、削除対象のユーザとトークンを発行したユーザを比較したいから

```ruby
    def destroy
      ## ユーザが自分自身だった場合
      if token_user == user
        errors = [{ name: 'user_id', message: t('.delete_self') }]
        return render 'api/errors', locals: { errors: }, status: :unprocessable_entity
      end
　   
      ...
    end
```

## 気になっていること
- concernで定義しているtoken_userをよんでいるのでパッと見token_userがどこで宣言されているのか分かりにくい気がする。