### PR TITLE
RSpecのリファクタリング

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,8 @@ AllCops:
     - node_modules/**/*
     - vendor/**/*
     - tmp/**/*
+
+# ネストの個数
+RSpec/NestedGroups:
+  Enabled: true
+  Max: 7 # default: 3

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,7 +19,7 @@ RSpec/MultipleExpectations:
 # ネストの個数
 RSpec/NestedGroups:
   Enabled: true
-  Max: 5 # default: 3
+  Max: 7 # default: 3
 
 # RSpecでインスタンス変数を使えないようにするか
 RSpec/InstanceVariable:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,11 +16,6 @@ RSpec/MultipleExpectations:
   Enabled: true
   Max: 5 # default: 1
 
-# ネストの個数
-RSpec/NestedGroups:
-  Enabled: true
-  Max: 7 # default: 3
-
 # RSpecでインスタンス変数を使えないようにするか
 RSpec/InstanceVariable:
   Enabled: false

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -11,34 +11,36 @@ RSpec.describe 'ApiUsers' do
 
     let(:target) { create(:user, :noadmin) }
 
-    context 'アクセストークンが有効の場合' do
+    context 'アクセストークンがある場合' do
       let(:user) { create(:user, :admin) }
-      let(:access_token) { AccessToken.new(email: user.email).encode }
       let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
 
-      it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
-        expect(subject).to be_successful
-        expect(subject.parsed_body.symbolize_keys).to include(
-          {
-            id:           target.id,
-            name:         target.name,
-            admin:        target.admin,
-            activated:    target.activated,
-            activated_at: target.activated_at&.iso8601(2),
-            created_at:   target.created_at.iso8601(2),
-            updated_at:   target.updated_at.iso8601(2)
-          }
-        )
+      context 'アクセストークンが有効期限内の場合' do
+        let(:access_token) { AccessToken.new(email: user.email).encode }
+
+        it 'ターゲットのIDのユーザ情報をレスポンスとして取得できる' do
+          expect(subject).to be_successful
+          expect(subject.parsed_body.symbolize_keys).to include(
+            {
+              id:           target.id,
+              name:         target.name,
+              admin:        target.admin,
+              activated:    target.activated,
+              activated_at: target.activated_at&.iso8601(2),
+              created_at:   target.created_at.iso8601(2),
+              updated_at:   target.updated_at.iso8601(2)
+            }
+          )
+        end
       end
-    end
 
-    context 'アクセストークンが有効期限切れの場合' do
-      let(:email) { 'hogehoge@example.com' }
-      let(:headers) { { 'Authorization' => "Bearer #{expired_access_token(email:)}" } }
+      context 'アクセストークンが有効期限切れの場合' do
+        let(:access_token) { expired_access_token(email: user.email) }
 
-      it '401でエラーメッセージを出力して失敗する' do
-        expect(subject).to be_unauthorized
-        expect(subject.parsed_body).to have_key('errors')
+        it '401でエラーメッセージを出力して失敗する' do
+          expect(subject).to be_unauthorized
+          expect(subject.parsed_body).to have_key('errors')
+        end
       end
     end
 
@@ -53,69 +55,71 @@ RSpec.describe 'ApiUsers' do
   describe 'POST /api/users' do
     subject { post '/api/users', headers:, params: }
 
-    context 'アクセストークンが有効の場合' do
-      let!(:user) { create(:user, :admin) }
-      let(:access_token) { AccessToken.new(email: user.email).encode }
+    context 'アクセストークンがある場合' do
       let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
+      let!(:user) { create(:user, :admin) }
 
-      context 'パラメータが適切な場合' do
-        context 'ユーザが存在する場合' do
-          let(:params) { { name: 'hogehgoe', email: user.email, password: 'foobar' } }
+      context 'アクセストークンが有効期限内の場合' do
+        let(:access_token) { AccessToken.new(email: user.email).encode }
 
-          it '422が返って、エラーメッセージを返すこと' do
-            expect { subject }.not_to change(User, :count)
-            expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.parsed_body).to have_key('errors')
+        context 'パラメータが適切な場合' do
+          context 'ユーザが存在する場合' do
+            let(:params) { { name: 'hogehgoe', email: user.email, password: 'foobar' } }
+
+            it '422が返って、エラーメッセージを返すこと' do
+              expect { subject }.not_to change(User, :count)
+              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response.parsed_body).to have_key('errors')
+            end
+          end
+
+          context 'ユーザが存在しない場合' do
+            let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+
+            it '201が返って、作成したユーザを返すこと' do
+              expect { subject }.to change(User, :count).by(1)
+              expect(response).to be_created
+              expect(response.parsed_body).to include(
+                *%w[id name admin activated activated_at created_at updated_at]
+              )
+            end
           end
         end
 
-        context 'ユーザが存在しない場合' do
-          let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+        context 'パラメータが適切でない場合' do
+          let(:wrong_cases) do
+            [
+              { name: '', email: 'test@example.com', password: 'foobar' },
+              { name: 'hogehgoe', email: '', password: 'foobar' },
+              { name: 'hogehoge', email: 'test@example.com', password: '' },
+              * %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com].map do |addr|
+                { name: 'hogehgoe', email: addr, password: 'foobar' }
+              end,
+              { name: 'a' * 51, email: 'test@example.com', password: 'foobar'  },
+              { name: 'hogehgoe', email: "#{'a' * 244}@example.com", password: 'foobar' },
+              { name: 'hogehoge', email: 'test@example.com', password: 'a' * 5 }
+            ]
+          end
 
-          it '201が返って、作成したユーザを返すこと' do
-            expect { subject }.to change(User, :count).by(1)
-            expect(response).to be_created
-            expect(response.parsed_body).to include(
-              *%w[id name admin activated activated_at created_at updated_at]
-            )
+          it '400が返って、エラーメッセージを返すこと' do
+            wrong_cases.each do |wrong_case|
+              expect { post '/api/users', headers:, params: wrong_case }.not_to change(User, :count)
+              expect(response).to be_bad_request
+              expect(response.parsed_body).to have_key('errors')
+            end
           end
         end
       end
 
-      context 'パラメータが適切でない場合' do
-        let(:wrong_cases) do
-          [
-            { name: '', email: 'test@example.com', password: 'foobar' },
-            { name: 'hogehgoe', email: '', password: 'foobar' },
-            { name: 'hogehoge', email: 'test@example.com', password: '' },
-            * %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com].map do |addr|
-              { name: 'hogehgoe', email: addr, password: 'foobar' }
-            end,
-            { name: 'a' * 51, email: 'test@example.com', password: 'foobar'  },
-            { name: 'hogehgoe', email: "#{'a' * 244}@example.com", password: 'foobar' },
-            { name: 'hogehoge', email: 'test@example.com', password: 'a' * 5 }
-          ]
+      context 'アクセストークンが有効期限切れの場合' do
+        let(:access_token) { expired_access_token(email: user.email) }
+        let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+
+        it '401でエラーメッセージを出力して失敗する' do
+          expect { subject }.not_to change(User, :count)
+          expect(response).to be_unauthorized
+          expect(response.parsed_body).to have_key('errors')
         end
-
-        it '400が返って、エラーメッセージを返すこと' do
-          wrong_cases.each do |wrong_case|
-            expect { post '/api/users', headers:, params: wrong_case }.not_to change(User, :count)
-            expect(response).to be_bad_request
-            expect(response.parsed_body).to have_key('errors')
-          end
-        end
-      end
-    end
-
-    context 'アクセストークンが有効期限切れの場合' do
-      let(:email) { 'test@example.com' }
-      let(:headers) { { 'Authorization' => "Bearer #{expired_access_token(email:)}" } }
-      let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
-
-      it '401でエラーメッセージを出力して失敗する' do
-        expect { subject }.not_to change(User, :count)
-        expect(response).to be_unauthorized
-        expect(response.parsed_body).to have_key('errors')
       end
     end
 


### PR DESCRIPTION
## やったこと

- 階層構造を次のように変更した
```rb
context '有効なアクセストークンの場合' do
  let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
  let(:access_token) {}
end
context '無効なアクセストークンの場合' do
  let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
  let(:access_token) {}
end
context 'アクセストークンがない時' do
end
```

↓

```rb
context 'アクセストークンがある場合' do
  let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
  context 'アクセストークンが有効期限内の場合' do
    let(:access_token) {}
  end
  context 'アクセストークンが有効期限切れの場合' do
    let(:access_token) {}
  end
end

context 'アクセストークンがない時' do
end
```

- `アクセストークンが有効期限切れの場合`のアクセストークンの生成に使うemailは`アクセストークンが有効期限内の場合`のものと同じにした

- contextのネストの数を上限7に設定した

CIが通っていないのはCIのPRがマージされていないので一旦なしでお願いします