### PR TITLE
fakerを使うように変更

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -102,13 +102,15 @@ RSpec.describe 'ApiUsers' do
               { name: '', email:, password: },
               { name:, email: '', password: },
               { name:, email:, password: '' },
-              * %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com].map do |addr|
-                { name:, email: addr, password: }
+              * %w[
+                user@example,com user_at_foo.org user.name@example. foo@bar_baz.com
+                foo@bar+baz.com
+              ].map do |wrong_email|
+                { name:, email: wrong_email, password: }
               end,
               { name: 'a' * 51, email:, password: },
               {
-                name:, email: "#{'a' * 244}@example.com",
-password:
+                name:, email: "#{'a' * 244}@example.com", password:
               },
               { name:, email:, password: 'a' * 5 }
             ]

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe 'ApiUsers' do
 
         context 'パラメータが適切な場合' do
           context 'ユーザが存在する場合' do
-            let(:params) { { name: 'hogehgoe', email: user.email, password: 'foobar' } }
+            let(:params) do
+              { name: Faker::Name.name, email: user.email, password: Faker::Internet.password(min_length: 6) }
+            end
 
             it '422が返って、エラーメッセージを返すこと' do
               expect { subject }.not_to change(User, :count)
@@ -74,7 +76,12 @@ RSpec.describe 'ApiUsers' do
           end
 
           context 'ユーザが存在しない場合' do
-            let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+            let(:params) do
+              {
+                name: Faker::Name.name, email: Faker::Internet.email,
+                password: Faker::Internet.password(min_length: 6)
+              }
+            end
 
             it '201が返って、作成したユーザを返すこと' do
               expect { subject }.to change(User, :count).by(1)
@@ -87,17 +94,23 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'パラメータが適切でない場合' do
+          let(:name) { Faker::Name.name }
+          let(:email) { Faker::Internet.email }
+          let(:password) { Faker::Internet.password(min_length: 6) }
           let(:wrong_cases) do
             [
-              { name: '', email: 'test@example.com', password: 'foobar' },
-              { name: 'hogehgoe', email: '', password: 'foobar' },
-              { name: 'hogehoge', email: 'test@example.com', password: '' },
+              { name: '', email:, password: },
+              { name:, email: '', password: },
+              { name:, email:, password: '' },
               * %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com].map do |addr|
-                { name: 'hogehgoe', email: addr, password: 'foobar' }
+                { name:, email: addr, password: }
               end,
-              { name: 'a' * 51, email: 'test@example.com', password: 'foobar'  },
-              { name: 'hogehgoe', email: "#{'a' * 244}@example.com", password: 'foobar' },
-              { name: 'hogehoge', email: 'test@example.com', password: 'a' * 5 }
+              { name: 'a' * 51, email:, password: },
+              {
+                name:, email: "#{'a' * 244}@example.com",
+password:
+              },
+              { name:, email:, password: 'a' * 5 }
             ]
           end
 
@@ -113,7 +126,9 @@ RSpec.describe 'ApiUsers' do
 
       context 'アクセストークンが有効期限切れの場合' do
         let(:access_token) { expired_access_token(email: user.email) }
-        let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+        let(:params) do
+          { name: Faker::Name.name, email: Faker::Internet.email, password: Faker::Internet.password(min_length: 6) }
+        end
 
         it '401でエラーメッセージを出力して失敗する' do
           expect { subject }.not_to change(User, :count)
@@ -124,7 +139,9 @@ RSpec.describe 'ApiUsers' do
     end
 
     context 'アクセストークンがない場合' do
-      let(:params) { { name: 'hogehgoe', email: 'test@example.com', password: 'foobar' } }
+      let(:params) do
+        { name: Faker::Name.name, email: Faker::Internet.email, password: Faker::Internet.password(min_length: 6) }
+      end
 
       it '400でエラーメッセージを出力して失敗する' do
         expect { subject }.not_to change(User, :count)


### PR DESCRIPTION
- name, email, passwordをFakerで生成するように変更
- `パラメータが適切でない場合`のname, email, passwordを事前に宣言するように変更
```rb
    context 'パラメータが適切でない場合' do
          let(:name) { Faker::Name.name }
          let(:email) { Faker::Internet.email }
          let(:password) { Faker::Internet.password(min_length: 6) }
          let(:wrong_cases) do
          ...
```


