### PR TITLE
returnの書き方を変更

### DIFF
--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -16,8 +16,8 @@ module Api
       email = params[:email]
       password = params[:password]
       user = User.find_by(email:)
-      return render_unauthorized unless user
-      return render_forbidden unless user.admin
+      render_unauthorized and return unless user
+      render_forbidden and return unless user.admin
 
       render_unauthorized unless user.authenticate(password)
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -20,7 +20,7 @@ module Api
       ## ユーザがすでに存在している時
       if User.exists?(email:)
         errors = [{ name: 'email', message: t('.exist_user') }]
-        return render 'api/errors', locals: { errors: }, status: :unprocessable_entity
+        render 'api/errors', locals: { errors: }, status: :unprocessable_entity and return
       end
 
       new_user = User.create(name:, email:, password:, password_confirmation:)

--- a/app/controllers/concerns/access_token_verifiable.rb
+++ b/app/controllers/concerns/access_token_verifiable.rb
@@ -11,7 +11,7 @@ module AccessTokenVerifiable
     authorization_header = request.headers['Authorization']
     access_token = authorization_header&.match(/Bearer (?<token>.+)/)&.[](:token)
 
-    return render_missing_token if access_token.nil?
+    render_missing_token and return if access_token.nil?
 
     begin
       AccessToken.from_token(access_token)


### PR DESCRIPTION
## やったこと
https://github.com/sls-training/2023-rails-sample/pull/38#discussion_r1200041951 を受けて`return render `を`render and return`に変更してみた。

変更するべきなのか気になるので意見が欲しいです。

## 気になっていること
- renderはhttps://github.com/rails/rails/blob/feacb99003813d10425bd861d4dae3a14e4a33fb/actionpack/lib/abstract_controller/rendering.rb#L22-L31 を見るとresponse_bodyを返すってことだと思う。
そう考えると`render and return`だと返り値はnilで関数としての返り値がresponse_body | nil か response_bodyで異なるのがどうなんだろうか？個人的にはわざわざand returnにする必要もない気がした
```ruby
##  ユーザがいない時
render 'hoge' and return unless user ## return nil
##  ユーザがいる時
render 'uouo' # return response_body
```

- `and render`の方が renderが並んで気持ちは良い
- 今回の`app/controllers/api/users_controller.rb`のような長い場合だとreturnしてるのがぱっと見わかりにくい気もする
