### PR TITLE
ユーザ管理用ページの認証を追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,11 @@
 module Admin
   class UsersController < ApplicationController
     before_action :require_admin_user
+
+    # GET /admin/users
     def index; end
+
+    private
 
     def require_admin_user
       return if logged_in? && current_user.admin?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,8 +12,7 @@ module Admin
       return if logged_in? && current_user.admin?
 
       store_location
-      flash[:danger] = 'エラー : 管理者ユーザでログインしてください'
-      redirect_to login_url, status: :see_other
+      redirect_to login_url, status: :see_other, flash: { danger: 'エラー : 管理者ユーザでログインしてください' }
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'net/https'
+require 'uri'
+
+module Admin
+  class UsersController < ApplicationController
+    before_action :logged_in_admin_user
+    def index; end
+
+    def logged_in_admin_user
+      return if logged_in? && current_user.admin?
+
+      store_location
+      flash[:danger] = 'エラー : 管理者ユーザでログインしてください'
+      redirect_to login_url, status: :see_other
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,10 +5,10 @@ require 'uri'
 
 module Admin
   class UsersController < ApplicationController
-    before_action :logged_in_admin_user
+    before_action :require_admin_user
     def index; end
 
-    def logged_in_admin_user
+    def require_admin_user
       return if logged_in? && current_user.admin?
 
       store_location

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'net/https'
-require 'uri'
-
 module Admin
   class UsersController < ApplicationController
     before_action :require_admin_user

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe 'AdminUsers' do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:no_admin_user) { create(:user, :noadmin) }
+
+  describe 'GET /admin/users' do
+    subject { get admin_users_path }
+
+    context 'ユーザが管理者の場合' do
+      before { log_in_as(admin_user) }
+
+      it '200が返って、アクセスできる' do
+        subject
+        expect(response).to be_successful
+      end
+    end
+
+    context 'ユーザが管理者ではない場合' do
+      before { log_in_as(no_admin_user) }
+
+      it 'ログインページにリダイレクトしてトーストメッセージを表示' do
+        expect(subject).to redirect_to login_url
+        expect(response).to have_http_status :see_other
+        expect(flash[:danger]).not_to be_nil
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトしてトーストメッセージを表示' do
+        expect(subject).to redirect_to login_url
+        expect(response).to have_http_status :see_other
+        expect(flash[:danger]).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 RSpec.describe 'AdminUsers' do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:no_admin_user) { create(:user, :noadmin) }
+  let!(:non_admin_user) { create(:user, :noadmin) }
 
   describe 'GET /admin/users' do
     subject { get admin_users_path }
@@ -18,7 +18,7 @@ RSpec.describe 'AdminUsers' do
     end
 
     context 'ユーザが管理者ではない場合' do
-      before { log_in_as(no_admin_user) }
+      before { log_in_as(non_admin_user) }
 
       it 'ログインページにリダイレクトしてトーストメッセージを表示' do
         expect(subject).to redirect_to login_url


### PR DESCRIPTION
## やったこと

- #53 の表示条件に沿って、controllerを作成してページの表示を制御するようにした

| 非ログイン or 非管理者アカウントログイン | 管理者アカウントログイン | 
| --- | --- |
| ログインページに戻ってエラーメッセージをトーストで表示| ⭕️ |

- viewのファイルだけ追加した
admin/usersにアクセスした時にページが表示されるようにviewのファイルを追加した


- ページの表示の制御のテストを追加した
  - 管理者アカウントログイしている時 
  - 非管理者アカウントログインしている時
  - 非ログインの時
