### PR TITLE
サイドバーに管理者用ページを追加

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -44,6 +44,15 @@
           </ul>
         </div>
       </li>
+      <% if current_user.admin? %>
+        <hr />
+        <li>管理者用</li>
+        <li>
+          <%= link_to admin_users_path, class:"nav-link #{'active' if current_page?(admin_users_path)}" do %>
+            <i class="icon-dashboard fas fa-user fa-sm text-black-100"></i>&nbsp;ユーザ管理
+          <% end %>
+        </li>
+      <%end%>
       <hr />
       <li>
         <%= link_to logout_path, class:"nav-link", data: { "turbo-method": :delete } do %>


### PR DESCRIPTION
## やったこと
#48 で作成したサイドーバーに管理者のためのユーザ管理のボタンを追加した(仕様 #54)

## before
<img width="1495" alt="スクリーンショット 2023-06-01 15 49 32" src="https://github.com/sls-training/2023-rails-sample/assets/53074461/3622f414-adf7-4f4e-b22b-cef41c56afed">

## after
<img width="1495" alt="スクリーンショット 2023-06-01 15 49 18" src="https://github.com/sls-training/2023-rails-sample/assets/53074461/8d22b7fa-b491-4edc-ba9d-0ca513125c5d">


