### PR TITLE
テストデータ生成の際にカラムが足りていなかったのを修正

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     activated { true }
     activated_at { Time.zone.now }
     admin { [true, false].sample }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
 
     trait :admin do
       admin { true }


### PR DESCRIPTION
## やったこと
- FactoryBotで生成しているユーザのテストデータに`created_at`, `updated_at`がなかったので追加した


## 目的
ユーザ生成をinsert_allする際にカラムが足りないことで実行できなかったため
```ruby
   let!(:user_list) do
      users = build_list(:user, 1000)
      User.insert_all users.map(&:attributes)
    end
```
