### PR TITLE
HTTPリクエストメソッドを実装

### DIFF
--- a/app/models/concerns/http_method.rb
+++ b/app/models/concerns/http_method.rb
@@ -8,13 +8,10 @@ module HttpMethod
 
   def get(url_path, params: {}, headers: {})
     uri = URI("#{BASE_URL}#{url_path}")
+    uri.query = URI.encode_www_form(params)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
-
-    path_with_query = [uri.path, URI.encode_www_form(params)]
-                        .compact_blank
-                        .join('?')
-    http.get(path_with_query, headers)
+    http.get(uri.to_s, headers)
   end
 
   def post(url_path, params: {}, headers: {})

--- a/app/models/concerns/http_method.rb
+++ b/app/models/concerns/http_method.rb
@@ -7,7 +7,7 @@ module HttpMethod
   BASE_URL = 'http://localhost:3000/api'
 
   def get(url_path, params: {}, headers: {})
-    uri = URI("#{BASE_URL}#{url_path}")
+    uri = URI(File.join(BASE_URL, url_path))
     uri.query = URI.encode_www_form(params)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
@@ -15,7 +15,7 @@ module HttpMethod
   end
 
   def post(url_path, params: {}, headers: {})
-    uri = URI("#{BASE_URL}#{url_path}")
+    uri = URI(File.join(BASE_URL, url_path))
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
     http.post(uri.path, params.to_json, headers)

--- a/app/models/concerns/http_method.rb
+++ b/app/models/concerns/http_method.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'net/https'
+require 'uri'
+
+module HttpMethod
+  BASE_URL = 'http://localhost:3000/api'
+
+  def get(url_path, params: {}, headers: {})
+    uri = URI("#{BASE_URL}#{url_path}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    path_with_query = [uri.path, URI.encode_www_form(params)]
+                        .compact_blank
+                        .join('?')
+    http.get(path_with_query, headers)
+  end
+
+  def post(url_path, params: {}, headers: {})
+    uri = URI("#{BASE_URL}#{url_path}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    http.post(uri.path, params.to_json, headers)
+  end
+end


### PR DESCRIPTION
## やったこと
models/concernにnet/httpのget, postをラップしたメソッドを作成した

以下のようにmodels/**.rbでget, postのhttpメソッドを呼ぶことを想定している(#68)
現在はget, postのみについて考えることとする(他のメソッドは別PR)
```ruby
class UsersApi
  extend HttpMethod

  class << self
    def create_token(email:, password:)
      response = post(...)
...
```
