### PR TITLE
トークン検証と生成を行う部分の作成

### DIFF
--- a/app/controllers/concerns/access_token_verifiable_for_api.rb
+++ b/app/controllers/concerns/access_token_verifiable_for_api.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AccessTokenVerifiableForApi
+  extend ActiveSupport::Concern
+
+  EMAIL = Rails.application.credentials.app.rails_sample_email
+  PASSWORD = Rails.application.credentials.app.rails_sample_password
+
+  included do
+    before_action :generate_and_verfiy_access_token
+  end
+
+  def raw_access_token
+    @raw_access_token ||= UsersApi.create_token(email: EMAIL, password: PASSWORD)
+  end
+
+  def access_token
+    @_access_token ||= AccessToken.from_token(raw_access_token) if raw_access_token.present?
+  end
+
+  private
+
+  def generate_and_verfiy_access_token
+    redirect_to_login and return if raw_access_token.nil?
+
+    begin
+      access_token
+    rescue JWT::DecodeError
+      redirect_to_login
+    end
+  end
+
+  def redirect_to_login
+    redirect_to login_url, flash: { danger: 'ログインし直してください' }
+  end
+end


### PR DESCRIPTION
## やったこと

APIを利用してアクセストークンを生成、検証を行うモジュールを作成した
(以前作成した`access_token_verifiable.rb`と似ていたのでそちらを参考にした)

email, passwordは#67 で作成したcredentialsから読み取るようにした
```
  EMAIL = Rails.application.credentials.app.rails_sample_email
  PASSWORD = Rails.application.credentials.app.rails_sample_password
```