### PR TITLE
sort_keyとorder_byの指定の方法を変更

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -60,12 +60,14 @@ module Api
     end
 
     def sort_key
-      @_sort_key ||= params.fetch(:sort_key, 'name')
+      sortable_keys = %w[name id activated_at created_at updated_at]
+      @_sort_key ||= sortable_keys.include?(params[:sort_key]) ? params[:sort_key] : 'name'
       @_sort_key
     end
 
     def order_by
-      @_order_by ||= params.fetch(:order_by, 'order_by')
+      orderable_keys = %w[asc desc]
+      @_order_by ||= orderable_keys.include?(params[:order_by]) ? params[:order_by] : 'asc'
       @_order_by
     end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -62,13 +62,11 @@ module Api
     def sort_key
       sortable_keys = %w[name id activated_at created_at updated_at]
       @_sort_key ||= sortable_keys.include?(params[:sort_key]) ? params[:sort_key] : 'name'
-      @_sort_key
     end
 
     def order_by
       orderable_keys = %w[asc desc]
       @_order_by ||= orderable_keys.include?(params[:order_by]) ? params[:order_by] : 'asc'
-      @_order_by
     end
 
     def limit

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -53,14 +53,28 @@ module Api
     private
 
     def users
-      sort_key = params.fetch(:sort_key, 'name')
-      order_by = params.fetch(:order_by, 'asc')
-      limit = [params.fetch(:limit, 50).to_i, 1000].min
-      offset = params[:offset]
       @_users ||= User
                     .order(sort_key => order_by)
                     .limit(limit)
                     .offset(offset)
+    end
+
+    def sort_key
+      @_sort_key ||= params.fetch(:sort_key, 'name')
+      @_sort_key
+    end
+
+    def order_by
+      @_order_by ||= params.fetch(:order_by, 'order_by')
+      @_order_by
+    end
+
+    def limit
+      @_limit ||= [params.fetch(:limit, 50).to_i, 1000].min
+    end
+
+    def offset
+      @_offset ||= params[:offset]
     end
 
     def user

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -5,6 +5,9 @@ module Api
     include AccessTokenVerifiable
     before_action :validate_user_id, only: %i[show destroy]
 
+    SORTABLE_KEYS = %w[name id activated_at created_at updated_at].freeze
+    ORDERABLE_KEYS = %w[asc desc].freeze
+
     # GET /api/users
     def index
       render :index, locals: { users: }
@@ -60,13 +63,11 @@ module Api
     end
 
     def sort_key
-      sortable_keys = %w[name id activated_at created_at updated_at]
-      @_sort_key ||= sortable_keys.include?(params[:sort_key]) ? params[:sort_key] : 'name'
+      @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'
     end
 
     def order_by
-      orderable_keys = %w[asc desc]
-      @_order_by ||= orderable_keys.include?(params[:order_by]) ? params[:order_by] : 'asc'
+      @_order_by ||= ORDERABLE_KEYS.include?(params[:order_by]) ? params[:order_by] : 'asc'
     end
 
     def limit

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,7 +10,11 @@ module Api
 
     # GET /api/users
     def index
-      render :index, locals: { users: }
+      @_users = User
+                  .order(sort_key => order_by)
+                  .limit(limit)
+                  .offset(offset)
+      render :index, locals: { users: @_users }
     end
 
     # GET /api/users/:id
@@ -54,13 +58,6 @@ module Api
     end
 
     private
-
-    def users
-      @_users ||= User
-                    .order(sort_key => order_by)
-                    .limit(limit)
-                    .offset(offset)
-    end
 
     def sort_key
       @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'


### PR DESCRIPTION
## 問題点
今の状態だとorder_byやsort_keyのクエリはあるがemptyの場合や'hogehoge'のような適当な文字列の場合、サーバーエラーになってしまいます。

※ 質問多めです

## やったこと

- sort_keyとorder_byに指定している文字列以外が来た場合にデフォルト値を返すように変更
- 行数が多くなったのでrubocopに警告出されたので関数に分けた

## わからないことなど
- APIであらかじめドキュメントに定めた文字列が来たときにはデフォルトで実行してしまうのがよいか、それともエラーを返す方が良いかがわからない。

- 行数の多さから関数に分けたが、users関数でしか使わない関数がいくつもあるのがよくない気がしています。
 一回modelに新たなクラスを作成して、そこでバリデーションをかけるということも考えたのですが、どうでしょうか？
(データを加工する => モデルの役割なんでしょうか？)