### PR TITLE
sort_key設定時のテストの作成 

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'idの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['id'] })
             end
           end
 
@@ -67,6 +68,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'nameの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['name'] })
             end
           end
 
@@ -75,6 +77,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'emailの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['email'] })
             end
           end
 
@@ -83,6 +86,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'activated_atの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['activated_at'] })
             end
           end
 
@@ -91,6 +95,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'created_atの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['created_at'] })
             end
           end
 
@@ -99,6 +104,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'updated_atの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['updated_at'] })
             end
           end
 
@@ -107,6 +113,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'nameの昇順でユーザの配列を取得できて、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['name'] })
             end
           end
         end
@@ -116,6 +123,7 @@ RSpec.describe 'ApiUsers' do
 
           it 'nameの昇順でuserの配列を取得できて、200を返す' do
             expect(subject).to be_successful
+            expect(subject.parsed_body).to eq(subject.parsed_body.sort_by { |a| a['name'] })
           end
         end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -55,37 +55,60 @@ RSpec.describe 'ApiUsers' do
           let(:params) { { sort_key: } }
 
           context 'sort_keyがidの場合' do
-            # TODO: idの昇順でuserの配列を取得できて、200を返すテストを作成する
+            let(:sort_key) { 'id' }
+
+            it 'idの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがnameの場合' do
-            # TODO: nameの昇順でuserの配列を取得できて、200を返すテストを作成する
+            let(:sort_key) { 'name' }
+
+            it 'nameの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがemailの場合' do
-            # TODO: emailの昇順でuserの配列を取得できて、200を返すテストを作成する
+            let(:sort_key) { 'email' }
+
+            it 'emailの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがactivated_atの場合' do
-            # TODO: activated_atの昇順でuserの配列を取得できて、200を返すテストを作成する
+            let(:sort_key) { 'activated_at' }
+
+            it 'activated_atの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがcreated_atの場合' do
-            # TODO: created_atの昇順でuserの配列を取得できて、200を返す'
+            let(:sort_key) { 'created_at' }
+
+            it 'created_atの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがupdated_atの場合' do
-            # TODO: updated_atの昇順でuserの配列を取得できて、200を返す'
+            let(:sort_key) { 'updated_at' }
+
+            it 'updated_atの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
 
           context 'sort_keyがid, name, email, activated_at, created_at, updated_at以外の場合' do
-            # TODO: nameの昇順でuserの配列を取得できて、200を返すテストを作成する
+            let(:sort_key) { 'hogehoge' }
+
+            it 'nameの昇順でユーザの配列を取得できて、200を返す' do
+            end
           end
         end
 
         context 'クエリにsort_keyがない場合' do
           let(:params) { {} }
-          # TODO: nameの昇順でuserの配列を取得できて、200を返すテストを作成する
+
+          it 'nameの昇順でuserの配列を取得できて、200を返す' do
+          end
         end
 
         context 'クエリにlimitがある場合' do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'id' }
 
             it 'idの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -65,6 +66,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'name' }
 
             it 'nameの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -72,6 +74,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'email' }
 
             it 'emailの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -79,6 +82,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'activated_at' }
 
             it 'activated_atの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -86,6 +90,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'created_at' }
 
             it 'created_atの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -93,6 +98,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'updated_at' }
 
             it 'updated_atの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
 
@@ -100,6 +106,7 @@ RSpec.describe 'ApiUsers' do
             let(:sort_key) { 'hogehoge' }
 
             it 'nameの昇順でユーザの配列を取得できて、200を返す' do
+              expect(subject).to be_successful
             end
           end
         end
@@ -108,6 +115,7 @@ RSpec.describe 'ApiUsers' do
           let(:params) { {} }
 
           it 'nameの昇順でuserの配列を取得できて、200を返す' do
+            expect(subject).to be_successful
           end
         end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'クエリにsort_keyがある場合' do
+          let(:params) { { sort_key: } }
+
           context 'sort_keyがidの場合' do
             # TODO: idの昇順でuserの配列を取得できて、200を返すテストを作成する
           end
@@ -82,6 +84,7 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'クエリにsort_keyがない場合' do
+          let(:params) { {} }
           # TODO: nameの昇順でuserの配列を取得できて、200を返すテストを作成する
         end
 


### PR DESCRIPTION
## 変更した点

- `context 'クエリにsort_keyがある場合`
sort_keyを設定している場合にユーザの配列をid, name, email, created_at, updated_at, activated_at、それ以外の場合についてそれぞれ昇順でユーザの配列を取得できているかどうかのテストを作成した

- `context 'クエリにsort_keyがない場合`
デフォルトのnameの昇順でユーザの配列を取得できているかどうかのテストを作成した

#78 の続き