### PR TITLE
limit設定時のテストの作成

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -4,13 +4,17 @@ require 'rails_helper'
 
 RSpec.describe 'ApiUsers' do
   describe 'GET /api/users' do
+    def create_user_list(count)
+      users = build_list(:user, count)
+      User.insert_all users.map(&:attributes)
+    end
+
     subject do
       get('/api/users', headers:, params:)
       response
     end
 
     let!(:current_user) { create(:user, :admin) }
-    let!(:user_list) { create_list(:user, 1500, :noadmin) }
 
     context 'アクセストークンがない場合' do
       let(:params) { {} }
@@ -92,11 +96,19 @@ RSpec.describe 'ApiUsers' do
             let(:limit) { 1001 }
 
             context 'ユーザ数が1000未満の場合' do
-              # TODO: ユーザ情報を上限数取得し、200を返すテストを作成する
+              before { create_user_list 150 }
+
+              it 'ユーザ情報を上限数取得し、200を返す' do
+                expect(subject).to be_successful
+              end
             end
 
-            context 'ユーザ数が#1000以上の場合' do
-              # TODO: ユーザ情報を1000まで取得し、200を返すテストを作成する
+            context 'ユーザ数が1000以上の場合' do
+              before { create_user_list 1500 }
+
+              it 'ユーザ情報を1000まで取得し、200を返す' do
+                expect(subject).to be_successful
+              end
             end
           end
 
@@ -104,11 +116,17 @@ RSpec.describe 'ApiUsers' do
             let(:limit) { 100 }
 
             context 'ユーザ数がlimit未満の場合' do
-              # TODO: ユーザ情報をlimit数分取得し、200を返すテストを作成する
+              before { create_user_list 50 }
+
+              it 'ユーザ情報を上限数分取得し、200を返す' do
+              end
             end
 
             context 'ユーザ数がlimit以上の場合' do
-              # TODO: ユーザ情報を上限数分取得し、200を返すテストを作成する
+              before { create_user_list 150 }
+
+              it 'ユーザ情報をlimit数分取得し、200を返す' do
+              end
             end
           end
         end
@@ -116,12 +134,20 @@ RSpec.describe 'ApiUsers' do
         context 'クエリにlimitがない場合' do
           let(:params) { {} }
 
-          context 'ユーザ数が50件未満の場合' do
-            # TODO: ユーザ情報を上限数取得し、200を返すテストを作成する
+          context 'ユーザ数が50未満の場合' do
+            before { create_user_list 10 }
+
+            it 'ユーザ情報を上限数取得し、200を返す' do
+              expect(subject).to be_successful
+            end
           end
 
-          context 'ユーザ数が50件以上の場合' do
-            # TODO: ユーザ情報を50件分取得し、200を返すテストを作成する
+          context 'ユーザ数が50以上の場合' do
+            before { create_user_list 100 }
+
+            it 'ユーザ情報を50件分取得し、200を返す' do
+              expect(subject).to be_successful
+            end
           end
         end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'ApiUsers' do
     end
 
     let!(:current_user) { create(:user, :admin) }
-    let!(:user_list) { create_list(:user, 50, :noadmin) }
+    let!(:user_list) { create_list(:user, 1500, :noadmin) }
 
     context 'アクセストークンがない場合' do
       let(:params) { {} }
@@ -89,6 +89,8 @@ RSpec.describe 'ApiUsers' do
           let(:params) { { limit: } }
 
           context 'limitが1000を超過する場合' do
+            let(:limit) { 1001 }
+
             context 'ユーザ数が1000未満の場合' do
               # TODO: ユーザ情報を上限数取得し、200を返すテストを作成する
             end
@@ -99,6 +101,8 @@ RSpec.describe 'ApiUsers' do
           end
 
           context 'limitが1000以下の場合' do
+            let(:limit) { 100 }
+
             context 'ユーザ数がlimit未満の場合' do
               # TODO: ユーザ情報をlimit数分取得し、200を返すテストを作成する
             end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'ApiUsers' do
             let(:limit) { 1001 }
 
             context 'ユーザ数が1000未満の場合' do
-              before { create_user_list 150 }
+              before { create_user_list 1 }
 
               it 'ユーザ情報を全件取得し、200を返す' do
                 expect(subject).to be_successful
@@ -118,7 +118,7 @@ RSpec.describe 'ApiUsers' do
             let(:limit) { 100 }
 
             context 'ユーザ数がlimit未満の場合' do
-              before { create_user_list 50 }
+              before { create_user_list 1 }
 
               it 'ユーザ情報を全件取得し、200を返す' do
                 expect(subject).to be_successful
@@ -127,7 +127,7 @@ RSpec.describe 'ApiUsers' do
             end
 
             context 'ユーザ数がlimit以上の場合' do
-              before { create_user_list 150 }
+              before { create_user_list 101 }
 
               it 'ユーザ情報をlimit数分取得し、200を返す' do
                 expect(subject).to be_successful

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -86,6 +86,8 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'クエリにlimitがある場合' do
+          let(:params) { { limit: } }
+
           context 'limitが1000を超過する場合' do
             context 'ユーザ数が1000未満の場合' do
               # TODO: ユーザ情報を上限数取得し、200を返すテストを作成する
@@ -108,6 +110,8 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'クエリにlimitがない場合' do
+          let(:params) { {} }
+
           context 'ユーザ数が50件未満の場合' do
             # TODO: ユーザ情報を上限数取得し、200を返すテストを作成する
           end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'ApiUsers' do
             context 'ユーザ数が1000未満の場合' do
               before { create_user_list 150 }
 
-              it 'ユーザ情報を上限数取得し、200を返す' do
+              it 'ユーザ情報を全件取得し、200を返す' do
                 expect(subject).to be_successful
                 expect(subject.parsed_body.count).to eq User.count
               end
@@ -120,7 +120,7 @@ RSpec.describe 'ApiUsers' do
             context 'ユーザ数がlimit未満の場合' do
               before { create_user_list 50 }
 
-              it 'ユーザ情報を上限数分取得し、200を返す' do
+              it 'ユーザ情報を全件取得し、200を返す' do
                 expect(subject).to be_successful
                 expect(subject.parsed_body.count).to eq User.count
               end
@@ -143,7 +143,7 @@ RSpec.describe 'ApiUsers' do
           context 'ユーザ数が50未満の場合' do
             before { create_user_list 10 }
 
-            it 'ユーザ情報を上限数取得し、200を返す' do
+            it 'ユーザ情報を全件取得し、200を返す' do
               expect(subject).to be_successful
               expect(subject.parsed_body.count).to eq User.count
             end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe 'ApiUsers' do
         context 'クエリにlimitがある場合' do
           let(:params) { { limit: } }
 
-          context 'limitが1000を超過する場合' do
+          context 'limitが1000件を超過する場合' do
             let(:limit) { 1001 }
 
-            context 'ユーザ数が1000未満の場合' do
+            context 'ユーザ数が1000件未満の場合' do
               before { create_user_list 1 }
 
               it 'ユーザ情報を全件取得し、200を返す' do
@@ -99,17 +99,17 @@ RSpec.describe 'ApiUsers' do
               end
             end
 
-            context 'ユーザ数が1000以上の場合' do
+            context 'ユーザ数が1000件以上の場合' do
               before { create_user_list limit }
 
-              it 'ユーザ情報を1000まで取得し、200を返す' do
+              it 'ユーザ情報を1000件取得し、200を返す' do
                 expect(subject).to be_successful
                 expect(subject.parsed_body.count).to eq 1000
               end
             end
           end
 
-          context 'limitが1000以下の場合' do
+          context 'limitが1000件以下の場合' do
             let(:limit) { 100 }
 
             context 'ユーザ数がlimit未満の場合' do
@@ -135,7 +135,7 @@ RSpec.describe 'ApiUsers' do
         context 'クエリにlimitがない場合' do
           let(:params) { {} }
 
-          context 'ユーザ数が50未満の場合' do
+          context 'ユーザ数が50件未満の場合' do
             before { create_user_list 1 }
 
             it 'ユーザ情報を全件取得し、200を返す' do
@@ -144,7 +144,7 @@ RSpec.describe 'ApiUsers' do
             end
           end
 
-          context 'ユーザ数が50以上の場合' do
+          context 'ユーザ数が50件以上の場合' do
             before { create_user_list 51 }
 
             it 'ユーザ情報を50件分取得し、200を返す' do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'ApiUsers' do
             end
 
             context 'ユーザ数が1000以上の場合' do
-              before { create_user_list 1500 }
+              before { create_user_list limit }
 
               it 'ユーザ情報を1000まで取得し、200を返す' do
                 expect(subject).to be_successful

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'ApiUsers' do
           let(:params) { {} }
 
           context 'ユーザ数が50未満の場合' do
-            before { create_user_list 10 }
+            before { create_user_list 1 }
 
             it 'ユーザ情報を全件取得し、200を返す' do
               expect(subject).to be_successful
@@ -150,7 +150,7 @@ RSpec.describe 'ApiUsers' do
           end
 
           context 'ユーザ数が50以上の場合' do
-            before { create_user_list 100 }
+            before { create_user_list 51 }
 
             it 'ユーザ情報を50件分取得し、200を返す' do
               expect(subject).to be_successful

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -4,11 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'ApiUsers' do
   describe 'GET /api/users' do
-    def create_user_list(count)
-      users = build_list(:user, count)
-      User.insert_all users.map(&:attributes)
-    end
-
     subject do
       get('/api/users', headers:, params:)
       response

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe 'ApiUsers' do
 
               it 'ユーザ情報を上限数取得し、200を返す' do
                 expect(subject).to be_successful
+                expect(subject.parsed_body.count).to eq User.count
               end
             end
 
@@ -108,6 +109,7 @@ RSpec.describe 'ApiUsers' do
 
               it 'ユーザ情報を1000まで取得し、200を返す' do
                 expect(subject).to be_successful
+                expect(subject.parsed_body.count).to eq 1000
               end
             end
           end
@@ -119,6 +121,8 @@ RSpec.describe 'ApiUsers' do
               before { create_user_list 50 }
 
               it 'ユーザ情報を上限数分取得し、200を返す' do
+                expect(subject).to be_successful
+                expect(subject.parsed_body.count).to eq User.count
               end
             end
 
@@ -126,6 +130,8 @@ RSpec.describe 'ApiUsers' do
               before { create_user_list 150 }
 
               it 'ユーザ情報をlimit数分取得し、200を返す' do
+                expect(subject).to be_successful
+                expect(subject.parsed_body.count).to eq limit
               end
             end
           end
@@ -139,6 +145,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'ユーザ情報を上限数取得し、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body.count).to eq User.count
             end
           end
 
@@ -147,6 +154,7 @@ RSpec.describe 'ApiUsers' do
 
             it 'ユーザ情報を50件分取得し、200を返す' do
               expect(subject).to be_successful
+              expect(subject.parsed_body.count).to eq 50
             end
           end
         end

--- a/spec/support/user_support.rb
+++ b/spec/support/user_support.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module UserSupport
+  def create_user_list(count)
+    users = build_list(:user, count)
+    User.insert_all users.map(&:attributes)
+  end
+end
+RSpec.configure { |config| config.include UserSupport }


### PR DESCRIPTION
## やったこと
- #76 のユーザの作成方法をメソッドにした
- limitが設定してある場合のユーザの配列の要素数があっているかどうか、200を返すかを検証した

以下のようにテストを行った

- クエリにlimitがある場合
  - limitが1000を超過する場合 (limitの上限は1000)
    - ユーザ数が1000未満
    - ユーザ数が1000以上
  - limitが1000以下の時
    - ユーザ数がlimit未満
    - ユーザ数がlimit以上
 
- クエリにlimitがない場合(limitのデフォルトが50)
  - ユーザ数が50未満
  - ユーザ数が50以上


#78 の続き
ユーザの作成方法を変えたことで#77, #79, #81 のテストが通らなくなる可能性が高いのでこちらは#77, #78, #79, #81見たあと一番最後に修正してマージします
