### PR TITLE
offset設定時のテストの作成 

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -119,12 +119,16 @@ RSpec.describe 'ApiUsers' do
 
         context 'クエリにoffsetがある場合' do
           let(:params) { { offset: } }
-          # TODO: offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返すテストを作成する
+
+          it 'offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返す' do
+          end
         end
 
         context 'クエリにoffsetがない場合' do
           let(:params) { {} }
-          # TODO: ユーザの配列をnameの昇順で取得し、200を返すテストを作成する
+
+          it 'ユーザの配列をnameの昇順で取得し、200を返す' do
+          end
         end
       end
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe 'ApiUsers' do
 
           it 'offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返す' do
             expect(subject).to be_successful
+            users = User
+                      .order(name: :asc)
+                      .offset(offset)
+                      .limit(50)
+                      .pluck('id')
+            expect(subject.parsed_body.pluck('id')).to eq users
           end
         end
 
@@ -131,6 +137,11 @@ RSpec.describe 'ApiUsers' do
 
           it 'ユーザの配列をnameの昇順で取得し、200を返す' do
             expect(subject).to be_successful
+            users = User
+                      .order(name: :asc)
+                      .limit(50)
+                      .pluck('id')
+            expect(subject.parsed_body.pluck('id')).to eq users
           end
         end
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe 'ApiUsers' do
           let(:params) { { offset: } }
 
           it 'offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返す' do
+            expect(subject).to be_successful
           end
         end
 
@@ -128,6 +129,7 @@ RSpec.describe 'ApiUsers' do
           let(:params) { {} }
 
           it 'ユーザの配列をnameの昇順で取得し、200を返す' do
+            expect(subject).to be_successful
           end
         end
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -118,10 +118,12 @@ RSpec.describe 'ApiUsers' do
         end
 
         context 'クエリにoffsetがある場合' do
+          let(:params) { { offset: } }
           # TODO: offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返すテストを作成する
         end
 
         context 'クエリにoffsetがない場合' do
+          let(:params) { {} }
           # TODO: ユーザの配列をnameの昇順で取得し、200を返すテストを作成する
         end
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe 'ApiUsers' do
 
         context 'クエリにoffsetがある場合' do
           let(:params) { { offset: } }
+          let(:offset) { 25 }
 
           it 'offset件数飛ばしてユーザの配列をnameの昇順で取得し、200を返す' do
             expect(subject).to be_successful


### PR DESCRIPTION
## やったこと
offsetを設定している場合にoffset分の件数飛ばしてユーザの配列を昇順で取得できているかどうかのテストを作成した
userにoffsetをかけて取得したものとidの順番が同じかどうかで判断した
```ruby
            users = User
                      .order(name: :asc) # default name, asc
                      .offset(offset)
                      .limit(50) # default 50
                      .pluck('id')
```

#78 の続き