### PR TITLE
ユーザ編集用APIの作成

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,7 @@
 module Api
   class UsersController < ApplicationController
     include AccessTokenVerifiable
-    before_action :validate_user_id, only: %i[show destroy]
+    before_action :validate_user_id, only: %i[show destroy update]
 
     SORTABLE_KEYS = %w[name id activated_at created_at updated_at].freeze
     ORDERABLE_KEYS = %w[asc desc].freeze

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -46,6 +46,22 @@ module Api
       end
     end
 
+    def update
+      name, email, admin, activated = update_params
+
+      ## ユーザがすでに存在している時
+      render_user_existing and return if User.exists?(email:)
+
+      if user.update(name:, email:, admin:, activated:)
+        # ユーザの更新に成功した場合
+        render :update, locals: { user: }, status: :ok
+      else
+        ## パラメータに不備があった場合
+        errors = user.errors.map { |x| { name: x.attribute, message: x.message } }
+        render 'api/errors', locals: { errors: }, status: :bad_request
+      end
+    end
+
     def destroy
       ## ユーザが自分自身だった場合
       if current_user == user

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -38,7 +38,7 @@ module Api
       new_user = ::User.create(name:, email:, password:, password_confirmation:)
       if new_user.invalid?
         ## パラメータに不備があった場合
-        errors = new_user.errors.map { |x| { name: x.attribute, message: x.message } }
+        errors = new_user.errors.map { |error| { name: error.attribute, message: error.message } }
         render 'api/errors', locals: { errors: }, status: :bad_request
       else
         # ユーザの作成に成功した場合
@@ -59,7 +59,7 @@ module Api
         render :update, locals: { user: }, status: :ok
       else
         ## パラメータに不備があった場合
-        errors = user.errors.map { |x| { name: x.attribute, message: x.message } }
+        errors = user.errors.map { |error| { name: error.attribute, message: error.message } }
         render 'api/errors', locals: { errors: }, status: :bad_request
       end
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -47,15 +47,13 @@ module Api
     end
 
     def update
-      name, email, admin, activated = update_params
-
       ## ユーザがすでに存在している時
-      if ::User.exists?(email:)
+      if user_params[:email] && ::User.exists?(email:)
         errors = [{ name: 'email', message: t('.exist_user') }]
         render 'api/errors', locals: { errors: }, status: :unprocessable_entity and return
       end
 
-      if user.update(name:, email:, admin:, activated:)
+      if user.update(user_params)
         # ユーザの更新に成功した場合
         render :update, locals: { user: }, status: :ok
       else
@@ -63,6 +61,11 @@ module Api
         errors = user.errors.map { |x| { name: x.attribute, message: x.message } }
         render 'api/errors', locals: { errors: }, status: :bad_request
       end
+    end
+
+    def user_params
+      # パラメータの一部を除外
+      params.require(:user).permit(:name, :email, :password, :admin, :activated)
     end
 
     def destroy
@@ -77,14 +80,6 @@ module Api
     end
 
     private
-
-    def update_params
-      name = params.fetch(:name, user.name)
-      email = params.fetch(:email, user.email)
-      admin = params.fetch(:admin, user.admin)
-      activated = params.fetch(:activated, user.activated)
-      [name, email, admin, activated]
-    end
 
     def sort_key
       @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,7 +48,8 @@ module Api
 
     def update
       ## ユーザがすでに存在している時
-      if user_params[:email] && ::User.exists?(email:)
+      email = user_params[:email]
+      if email && ::User.exists?(email:)
         errors = [{ name: 'email', message: t('.exist_user') }]
         render 'api/errors', locals: { errors: }, status: :unprocessable_entity and return
       end
@@ -77,7 +78,7 @@ module Api
     private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :admin, :activated)
+      params.permit(:name, :email, :password, :admin, :activated)
     end
 
     def sort_key

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -50,7 +50,7 @@ module Api
       name, email, admin, activated = update_params
 
       ## ユーザがすでに存在している時
-      render_user_existing and return if User.exists?(email:)
+      render_user_existing and return if ::User.exists?(email:)
 
       if user.update(name:, email:, admin:, activated:)
         # ユーザの更新に成功した場合

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -67,6 +67,11 @@ module Api
       [name, email, admin, activated]
     end
 
+    def render_user_existing
+      errors = [{ name: 'email', message: t('.exist_user') }]
+      render 'api/errors', locals: { errors: }, status: :unprocessable_entity
+    end
+
     def sort_key
       @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -50,7 +50,10 @@ module Api
       name, email, admin, activated = update_params
 
       ## ユーザがすでに存在している時
-      render_user_existing and return if ::User.exists?(email:)
+      if ::User.exists?(email:)
+        errors = [{ name: 'email', message: t('.exist_user') }]
+        render 'api/errors', locals: { errors: }, status: :unprocessable_entity and return
+      end
 
       if user.update(name:, email:, admin:, activated:)
         # ユーザの更新に成功した場合
@@ -81,11 +84,6 @@ module Api
       admin = params.fetch(:admin, user.admin)
       activated = params.fetch(:activated, user.activated)
       [name, email, admin, activated]
-    end
-
-    def render_user_existing
-      errors = [{ name: 'email', message: t('.exist_user') }]
-      render 'api/errors', locals: { errors: }, status: :unprocessable_entity
     end
 
     def sort_key

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -59,6 +59,14 @@ module Api
 
     private
 
+    def update_params
+      name = params.fetch(:name, user.name)
+      email = params.fetch(:email, user.email)
+      admin = params.fetch(:admin, user.admin)
+      activated = params.fetch(:activated, user.activated)
+      [name, email, admin, activated]
+    end
+
     def sort_key
       @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -63,11 +63,6 @@ module Api
       end
     end
 
-    def user_params
-      # パラメータの一部を除外
-      params.require(:user).permit(:name, :email, :password, :admin, :activated)
-    end
-
     def destroy
       ## ユーザが自分自身だった場合
       if current_user == user
@@ -80,6 +75,11 @@ module Api
     end
 
     private
+
+    def user_params
+      # パラメータの一部を除外
+      params.require(:user).permit(:name, :email, :password, :admin, :activated)
+    end
 
     def sort_key
       @_sort_key ||= SORTABLE_KEYS.include?(params[:sort_key]) ? params[:sort_key] : 'name'

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -77,7 +77,6 @@ module Api
     private
 
     def user_params
-      # パラメータの一部を除外
       params.require(:user).permit(:name, :email, :password, :admin, :activated)
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe 'ApiUsers' do
       context 'アクセストークンが有効期限内の場合' do
         let(:access_token) { AccessToken.new(email: user.email).encode }
 
-        context 'nameが空の場合' do
+        context '不正なユーザーデータが指定された場合' do
           let(:params) { { name: '' } }
 
           it '400が返って、エラーメッセージを返すこと' do
@@ -509,90 +509,25 @@ RSpec.describe 'ApiUsers' do
           end
         end
 
-        context 'emailが空の場合' do
-          let(:params) { { email: '' } }
+        context '正しいユーザーデータが指定された場合' do
+          context 'emailがすでに存在するユーザのemailの場合' do
+            let(:params) { { email: user.email } }
 
-          it '400が返って、エラーメッセージを返すこと' do
-            expect(subject).to be_bad_request
-            expect(subject.parsed_body).to have_key('errors')
+            it '422が返って、エラーメッセージを返すこと' do
+              expect(subject).to have_http_status :unprocessable_entity
+              expect(subject.parsed_body).to have_key('errors')
+            end
           end
-        end
 
-        context 'nameが51文字以上の場合' do
-          let(:params) { { name: 'a' * 51 } }
+          context 'emailのユーザが存在しない場合' do
+            let(:params) { { email: Faker::Internet.email } }
 
-          it '400が返って、エラーメッセージを返すこと' do
-            expect(subject).to be_bad_request
-            expect(subject.parsed_body).to have_key('errors')
-          end
-        end
-
-        context 'emailの形式が間違っている場合' do
-          let(:params) { { email: 'user@example,com' } }
-
-          it '400が返って、エラーメッセージを返すこと' do
-            expect(subject).to be_bad_request
-            expect(subject.parsed_body).to have_key('errors')
-          end
-        end
-
-        context 'emailが256文字以上の場合' do
-          let(:params) { { email: "#{'a' * 244}@example.com" } }
-
-          it '400が返って、エラーメッセージを返すこと' do
-            expect(subject).to be_bad_request
-            expect(subject.parsed_body).to have_key('errors')
-          end
-        end
-
-        context 'passwordが6文字未満の場合' do
-          let(:params) { { password: 'a' * 5 } }
-
-          it '400が返って、エラーメッセージを返すこと' do
-            expect(subject).to be_bad_request
-            expect(subject.parsed_body).to have_key('errors')
-          end
-        end
-
-        context 'emailがすでに存在するユーザのemailの場合' do
-          let(:params) { { email: user.email } }
-
-          it '422が返って、エラーメッセージを返すこと' do
-            expect(subject).to have_http_status :unprocessable_entity
-            expect(subject.parsed_body).to have_key('errors')
-          end
-        end
-
-        context 'nameが51未満の場合' do
-          let(:params) { { name: Faker::Name.name } }
-
-          it '200が返って、編集したユーザを返すこと' do
-            expect(subject).to be_successful
-            expect(subject.parsed_body).to include(
-              *%w[id name admin activated activated_at created_at updated_at]
-            )
-          end
-        end
-
-        context 'emailのユーザが存在しない場合' do
-          let(:params) { { email: Faker::Internet.email } }
-
-          it '200が返って、編集したユーザを返すこと' do
-            expect(subject).to be_successful
-            expect(subject.parsed_body).to include(
-              *%w[id name admin activated activated_at created_at updated_at]
-            )
-          end
-        end
-
-        context 'passwordが6文字以上の場合' do
-          let(:params) { { password: Faker::Internet.password(min_length: 6) } }
-
-          it '200が返って、編集したユーザを返すこと' do
-            expect(subject).to be_successful
-            expect(subject.parsed_body).to include(
-              *%w[id name admin activated activated_at created_at updated_at]
-            )
+            it '200が返って、編集したユーザを返すこと' do
+              expect(subject).to be_successful
+              expect(subject.parsed_body).to include(
+                *%w[id name admin activated activated_at created_at updated_at]
+              )
+            end
           end
         end
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe 'ApiUsers' do
         context 'nameが51未満の場合' do
           let(:params) { { name: Faker::Name.name } }
 
-          it '200が返って、作成したユーザを返すこと' do
+          it '200が返って、編集したユーザを返すこと' do
             expect(subject).to be_successful
             expect(subject.parsed_body).to include(
               *%w[id name admin activated activated_at created_at updated_at]
@@ -577,7 +577,7 @@ RSpec.describe 'ApiUsers' do
         context 'emailのユーザが存在しない場合' do
           let(:params) { { email: Faker::Internet.email } }
 
-          it '200が返って、作成したユーザを返すこと' do
+          it '200が返って、編集したユーザを返すこと' do
             expect(subject).to be_successful
             expect(subject.parsed_body).to include(
               *%w[id name admin activated activated_at created_at updated_at]
@@ -588,7 +588,7 @@ RSpec.describe 'ApiUsers' do
         context 'passwordが6文字以上の場合' do
           let(:params) { { password: Faker::Internet.password(min_length: 6) } }
 
-          it '200が返って、作成したユーザを返すこと' do
+          it '200が返って、編集したユーザを返すこと' do
             expect(subject).to be_successful
             expect(subject.parsed_body).to include(
               *%w[id name admin activated activated_at created_at updated_at]

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -459,4 +459,94 @@ RSpec.describe 'ApiUsers' do
       end
     end
   end
+
+  describe 'PATCH /api/users/:id' do
+    subject do
+      patch("/api/users/#{target_user.id}", headers:, params:)
+      response
+    end
+
+    let!(:target_user) { create(:user) }
+
+    context 'アクセストークンがない場合' do
+      let(:params) do
+        { name: Faker::Name.name, email: Faker::Internet.email }
+      end
+
+      it '400でエラーメッセージを出力して失敗する' do
+        expect(subject).to be_bad_request
+        expect(subject.parsed_body).to have_key('errors')
+      end
+    end
+
+    context 'アクセストークンがある場合' do
+      let(:headers) { { 'Authorization' => "Bearer #{access_token}" } }
+      let!(:user) { create(:user, :admin) }
+
+      context 'アクセストークンが有効期限切れの場合' do
+        let(:access_token) { expired_access_token(email: user.email) }
+        let(:params) do
+          { name: Faker::Name.name, email: Faker::Internet.email, password: Faker::Internet.password(min_length: 6) }
+        end
+
+        it '401でエラーメッセージを出力して失敗する' do
+          expect(subject).to be_unauthorized
+          expect(subject.parsed_body).to have_key('errors')
+        end
+      end
+
+      context 'アクセストークンが有効期限内の場合' do
+        let(:access_token) { AccessToken.new(email: user.email).encode }
+
+        context 'パラメータが適切でない場合' do
+          let(:name) { Faker::Name.name }
+          let(:email) { Faker::Internet.email }
+          let(:wrong_cases) do
+            [
+              { name: '', email: },
+              { name:, email: '' },
+              * %w[
+                user@example,com user_at_foo.org user.name@example. foo@bar_baz.com
+                foo@bar+baz.com
+              ].map { |wrong_email| { name:, email: wrong_email } },
+              { name: 'a' * 51, email: },
+              { name:, email: "#{'a' * 244}@example.com" }
+            ]
+          end
+
+          it '400が返って、エラーメッセージを返すこと' do
+            wrong_cases.each do |wrong_case|
+              patch("/api/users/#{target_user.id}", headers:, params: wrong_case)
+              expect(response).to be_bad_request
+              expect(response.parsed_body).to have_key('errors')
+            end
+          end
+        end
+
+        context 'パラメータが適切な場合' do
+          context 'ユーザが存在する場合' do
+            let(:params) do
+              { name: Faker::Name.name, email: user.email }
+            end
+
+            it '422が返って、エラーメッセージを返すこと' do
+              expect(subject).to have_http_status :unprocessable_entity
+              expect(subject.parsed_body).to have_key('errors')
+            end
+          end
+
+          context 'ユーザが存在しない場合' do
+            let(:params) { { name: Faker::Name.name, email: Faker::Internet.email } }
+
+            it '200が返って、作成したユーザを返すこと' do
+              expect(subject).to be_successful
+              expect(subject.parsed_body).to include(
+                *%w[id name admin activated activated_at created_at updated_at]
+              )
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -468,7 +468,7 @@ RSpec.describe 'ApiUsers' do
 
     let(:admin) { [true, false].sample }
     let(:activated) { [true, false].sample }
-    let!(:target_user) { create(:user) }
+    let(:target_user) { create(:user) }
 
     context 'アクセストークンがない場合' do
       let(:params) do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -466,11 +466,13 @@ RSpec.describe 'ApiUsers' do
       response
     end
 
+    let(:admin) { [true, false].sample }
+    let(:activated) { [true, false].sample }
     let!(:target_user) { create(:user) }
 
     context 'アクセストークンがない場合' do
       let(:params) do
-        { name: Faker::Name.name, email: Faker::Internet.email }
+        { name: Faker::Name.name, email: Faker::Internet.email, admin:, activated: }
       end
 
       it '400でエラーメッセージを出力して失敗する' do
@@ -486,7 +488,7 @@ RSpec.describe 'ApiUsers' do
       context 'アクセストークンが有効期限切れの場合' do
         let(:access_token) { expired_access_token(email: user.email) }
         let(:params) do
-          { name: Faker::Name.name, email: Faker::Internet.email, password: Faker::Internet.password(min_length: 6) }
+          { name: Faker::Name.name, email: Faker::Internet.email, admin:, activated: }
         end
 
         it '401でエラーメッセージを出力して失敗する' do
@@ -526,7 +528,7 @@ RSpec.describe 'ApiUsers' do
         context 'パラメータが適切な場合' do
           context 'ユーザが存在する場合' do
             let(:params) do
-              { name: Faker::Name.name, email: user.email }
+              { name: Faker::Name.name, email: user.email, admin:, activated: }
             end
 
             it '422が返って、エラーメッセージを返すこと' do
@@ -536,7 +538,9 @@ RSpec.describe 'ApiUsers' do
           end
 
           context 'ユーザが存在しない場合' do
-            let(:params) { { name: Faker::Name.name, email: Faker::Internet.email } }
+            let(:params) do
+              { name: Faker::Name.name, email: Faker::Internet.email, admin:, activated: }
+            end
 
             it '200が返って、作成したユーザを返すこと' do
               expect(subject).to be_successful


### PR DESCRIPTION
## やったこと

ユーザ編集用API(#90)とそのテストを作成した

## ~変更点など~

- ~行数多すぎたのでparamsを取得する部分とユーザがすでに存在する場合のrenderメソッドを分離した~


## 追加の修正箇所(6/20変更箇所)

- before_actionでupdateも検証するように変更した
 https://github.com/sls-training/2023-rails-sample/blob/7eec25fcea4e2474659fd2896612655bbbc18341/app/controllers/api/users_controller.rb#L5-L7

- User.updateで更新するパラメータにstrong parameterで取得した値を直接入力できるように変更した
https://github.com/sls-training/2023-rails-sample/blob/7eec25fcea4e2474659fd2896612655bbbc18341/app/controllers/api/users_controller.rb#L49-L60
https://github.com/sls-training/2023-rails-sample/blob/7eec25fcea4e2474659fd2896612655bbbc18341/app/controllers/api/users_controller.rb#L80-L82


- passwordがパラメータとして含まれていなかったので追加した

その際にspecがエラーになってしまい、シンプルに今まで一括検証していたitを一つずつ検証するように変更した
https://github.com/sls-training/2023-rails-sample/blob/7eec25fcea4e2474659fd2896612655bbbc18341/spec/requests/api/users_spec.rb#L500-L600





## 備考
~#91, #92 の後続MR~