### PR TITLE
削除用のAPIを呼ぶ関数を実装

### DIFF
--- a/app/models/api/user.rb
+++ b/app/models/api/user.rb
@@ -34,6 +34,17 @@ module Api
         end
       end
 
+      def destroy(access_token:, id:)
+        headers = { 'Authorization' => "Bearer #{access_token}" }
+        response = delete("/users/#{id}", headers:)
+        return true if response.is_a?(Net::HTTPNoContent)
+
+        errors = JSON.parse(response.body, symbolize_names: true)[:errors]
+        errors.map do |error|
+          Api::Error.from_json error
+        end
+      end
+
       def from_json(json)
         id, name, email, admin, activated, activated_at, created_at, updated_at = json.values_at(
           :id, :name, :email, :admin,

--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -34,4 +34,116 @@ RSpec.describe 'User' do
       end
     end
   end
+
+  describe '#destroy' do
+    subject { Api::User.destroy(access_token:, id:) }
+
+    let(:target_user) { create(:user) }
+    let(:current_user) { create(:user, :admin) }
+
+    let(:valid_token) { AccessToken.new(email: current_user.email).encode }
+
+    before { WebMock.enable! }
+
+    context 'アクセストークンがない場合' do
+      before do
+        WebMock
+          .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+          .to_return(
+            body:   {
+              errors: [
+                {
+                  name:    'access_token',
+                  message: 'authentication token is missing'
+                }
+              ]
+            }.to_json,
+            status: 400
+          )
+      end
+
+      let(:access_token) { nil }
+      let(:id) { target_user.id }
+
+      it 'エラーの入った配列が返る' do
+        expect(subject).to include Api::Error
+      end
+    end
+
+    context 'アクセストークンがある場合' do
+      let(:current_user) { create(:user, :admin) }
+
+      context 'アクセストークンが有効期限切れの場合' do
+        before do
+          WebMock
+            .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+            .with(headers: { Authorization: "Bearer #{access_token}" })
+            .to_return(
+              body:   {
+                errors: [
+                  {
+                    token:   'access_token',
+                    message: 'Invalid token'
+                  }
+                ]
+              }.to_json,
+              status: 401
+            )
+        end
+
+        let(:access_token) { expired_access_token(email: current_user.email) }
+        let(:id) { target_user.id }
+
+        it 'エラーの入った配列が返る' do
+          expect(subject).to include Api::Error
+        end
+      end
+
+      context 'アクセストークンが有効期限内の場合' do
+        let(:access_token) { valid_token }
+
+        context '自分のIDを指定した場合' do
+          let(:id) { current_user.id }
+
+          before do
+            WebMock
+              .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+              .with(headers: { Authorization: "Bearer #{access_token}" })
+              .to_return(
+                body:   {
+                  errors: [
+                    {
+                      name:    'user_id',
+                      message: "You can't delete yourself"
+                    }
+                  ]
+                }.to_json,
+                status: 401
+              )
+          end
+
+          it 'エラーの入った配列が返る' do
+            expect(subject).to include Api::Error
+          end
+        end
+
+        context '自分以外のIDを指定した場合' do
+          let(:id) { target_user.id }
+
+          before do
+            WebMock
+              .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+              .with(headers: { Authorization: "Bearer #{access_token}" })
+              .to_return(
+                status: 204
+              )
+          end
+
+          it 'trueが返る' do
+            expect(subject).to be_truthy
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
削除用のAPIを呼ぶための関数を実装した

削除用のAPIを呼ぶと成功するとNoContent 204なので何も返さず, 失敗するとerrorの配列のjsonを返す。
成功した時にtrue, 失敗した時にApi::Errorの配列を返すようにした(※1)

## 気になっていること

- get_list関数についても言えることだが、戻り値の型が成功しとときと失敗した時に違うのが良くないように思える。特に今回の場合、返り値はbooleanにして成否を確認したいがその場合、エラーオブジェクトをどうやって返せば良いか迷っている(※1)

- テストについてget_listの時にも言われたことだが、destroyが返すオブジェクトについては検証できるが、APIを呼んでいるかどうかについては検証できないことについてはどう対処すべきなのかわからなかった