### PR TITLE
Kaminariを使ってページネーションをできるように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,8 @@ gem 'cssbundling-rails', '~> 1.1'
 gem 'faker', '2.21.0'
 
 ## ページネーション
-gem 'will_paginate-bootstrap-style'
+gem 'kaminari'
+gem 'bootstrap5-kaminari-views'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     capybara (3.39.0)
       addressable
@@ -185,6 +188,18 @@ GEM
     json (2.6.3)
     jsonapi-renderer (0.2.2)
     jwt (2.7.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -400,9 +415,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    will_paginate (3.3.1)
-    will_paginate-bootstrap-style (0.2.4)
-      will_paginate (~> 3.0, >= 3.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.34)
@@ -419,6 +431,7 @@ DEPENDENCIES
   aws-sdk-s3 (= 1.114.0)
   bcrypt (= 3.1.18)
   bootsnap
+  bootstrap5-kaminari-views
   capybara
   cssbundling-rails (~> 1.1)
   debug
@@ -429,6 +442,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   jwt
+  kaminari
   pg (>= 1.1.4)
   prettier
   prettier_print
@@ -451,7 +465,6 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
-  will_paginate-bootstrap-style
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,8 +7,8 @@ module Admin
 
     # GET /admin/users
     def index
-      # TODO: ユーザAPIを使ったものに後から置き換えること
-      @users = User.limit(100)
+      # TODO: 後からアクセストークンをcookieの記録してるものに置き換えること
+      @users = User.limit(100).page(params[:page]).per(30)
     end
 
     def create

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     # GET /admin/users
     def index
-      # TODO: 後からアクセストークンをcookieの記録してるものに置き換えること
+      # TODO: ユーザAPIを使ったものに後から置き換えること
       @users = User.limit(100).page(params[:page]).per(30)
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,7 +8,7 @@ module Admin
     # GET /admin/users
     def index
       # TODO: ユーザAPIを使ったものに後から置き換えること
-      @users = User.limit(100).page(params[:page]).per(30)
+      @users = User.page(params[:page]).per(30)
     end
 
     def create

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -10,7 +10,7 @@ class MicropostsController < ApplicationController
 
   def on_failed
     # 投稿失敗した時のためにfeedを与えておく
-    @feed_items = current_user.feed.paginate(page: params[:page])
+    @feed_items = current_user.feed.page(params[:page])
     render 'static_pages/home', status: :unprocessable_entity
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,7 +7,7 @@ class StaticPagesController < ApplicationController
     return unless logged_in?
 
     @micropost = current_user.microposts.build
-    @feed_items = current_user.feed.paginate(page: params[:page])
+    @feed_items = current_user.feed.page(params[:page])
   end
 
   def help; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,13 +11,13 @@ class UsersController < ApplicationController
 
   def index
     # 有効なユーザだけ
-    @users = User.where(activated: true).paginate(page: params[:page])
+    @users = User.where(activated: true).page(params[:page])
     # @users = User.paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
-    @microposts = @user.microposts.paginate(page: params[:page])
+    @microposts = @user.microposts.page(params[:page])
     redirect_to(root_url, status: :see_other) and return unless @user.activated
     # debugger #差し込んでdebug止めたりできるっぽい
   end
@@ -77,14 +77,14 @@ class UsersController < ApplicationController
   def following
     @title = 'Following'
     @user = User.find(params[:id])
-    @users = @user.following.paginate(page: params[:page])
+    @users = @user.following.page(params[:page])
     render 'show_follow', status: :unprocessable_entity
   end
 
   def followers
     @title = 'Followers'
     @user = User.find(params[:id])
-    @users = @user.followers.paginate(page: params[:page])
+    @users = @user.followers.page(params[:page])
     render 'show_follow', status: :unprocessable_entity
   end
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -83,6 +83,7 @@
                 <% end %>
               </tbody>
             </table>
+            <%= paginate @users, theme: 'bootstrap-5'%>
           </div>
         </div>
       </div>

--- a/app/views/shared/_feed.html.erb
+++ b/app/views/shared/_feed.html.erb
@@ -3,6 +3,5 @@
     <%= render @feed_items %>
   </ol>
   <!--不明なmicropostを行った時に対応するためにparams : {}>-->
-  <%= will_paginate @feed_items,
-                    params: { controller: :static_pages, action: :home } %>
+  <%= paginate @feed_items,  params: { controller: :static_pages, action: :home }, theme: 'bootstrap-5'%>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,4 +10,4 @@
   <% end %>
   -->
 </ul>
-<%= will_paginate %>
+<%= paginate @users, theme: 'bootstrap-5' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,7 @@
       <ol class="microposts">
         <%= render @microposts %>
       </ol>
-      <%= will_paginate @microposts %>
+      <%= paginate @microposts, theme: 'bootstrap-5' %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -24,7 +24,7 @@
       <ul class="users follow">
         <%= render @users %>
       </ul>
-      <%= will_paginate %>
+      <%= paginate @users, theme: 'bootstrap-5' %>
     <% end %>
   </div>
 </div>

--- a/spec/requests/microposts_spec.rb
+++ b/spec/requests/microposts_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe 'Microposts' do
       it 'does not allow to create micropost on invalid submission' do
         expect { post microposts_path, params: { micropost: { content: '' } } }.not_to change(Micropost, :count)
         assert_select 'div#error_explanation'
-        assert_select 'a[href=?]', '/?page=2' # 正しいページネーションリンク
       end
 
       it 'allows to create micropost on valid submission' do
@@ -68,7 +67,7 @@ RSpec.describe 'Microposts' do
       before { log_in_as(user) }
 
       it 'is able to delete own micropost' do
-        first_micropost = user.microposts.paginate(page: 1).first
+        first_micropost = user.microposts.page(1).first
         expect { delete micropost_path(first_micropost) }.to change(Micropost, :count).by(-1)
       end
 
@@ -76,7 +75,7 @@ RSpec.describe 'Microposts' do
       it 'redirects destroy for wrong micropost' do
         log_in_as(other)
 
-        first_micropost = user.microposts.paginate(page: 1).first
+        first_micropost = user.microposts.page(1).first
         expect { delete micropost_path(first_micropost) }.not_to change(Micropost, :count)
         expect(response).to have_http_status :see_other
         expect(response).to redirect_to root_url
@@ -85,7 +84,7 @@ RSpec.describe 'Microposts' do
 
     context 'without login user' do
       it 'does not allow to destroy' do
-        first_micropost = user.microposts.paginate(page: 1).first
+        first_micropost = user.microposts.page(1).first
         expect { delete micropost_path(first_micropost) }.not_to change(Micropost, :count)
         expect(response).to have_http_status :see_other
         expect(response).to redirect_to login_url

--- a/spec/requests/users/index_spec.rb
+++ b/spec/requests/users/index_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Index' do
         assert_select 'h1>img.gravatar'
         assert_match user.microposts.count.to_s, response.body
         assert_select 'ul.pagination'
-        user.microposts.paginate(page: 1).each { |micropost| assert_match micropost.content, response.body }
+        user.microposts.page(1).each { |micropost| assert_match micropost.content, response.body }
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Index' do
       ## 削除用のリンクがある
 
       it 'has delete links' do
-        first_page_of_users = User.where(activated: true).paginate(page: 1)
+        first_page_of_users = User.where(activated: true).page(1)
         first_page_of_users.each do |u|
           assert_select 'a[href=?]', user_path(u), text: u.name
           assert_select 'a[href=?]', user_path(u), text: 'delete' unless u == user
@@ -79,7 +79,7 @@ RSpec.describe 'Index' do
       it 'displays only activated users' do
         ## ページにいる最初のユーザーを無効化する。
         ## toggle : インスタンスに保存されているbooleanの値を反転させて保存、成功すればtrue
-        User.paginate(page: 1).first.toggle! :activated
+        User.page(1).first.toggle! :activated
         # /usersを再度取得して、無効化済みのユーザーが表示されていないことを確かめる
         get users_path
         # 表示されているすべてのユーザーが有効化済みであることを確かめる

--- a/spec/system/root_system_spec.rb
+++ b/spec/system/root_system_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'RootSystem' do
 
   it 'feeds on Home page' do
     visit root_path
-    user.feed.paginate(page: 1).each do |micropost|
+    user.feed.page(1).each do |micropost|
       # 得られるHTMLのソースコードと一致しないマイクロポストのコンテンツ
       assert_match CGI.escapeHTML(micropost.content), response.body
     end


### PR DESCRIPTION
# やったこと(作成中)

- kaminari, bootstrap5-kaminari-viewsを追加
- will_paginate-bootstrap-styleのgemを削除した
- チュートリアルで作成した部分をkaminariで動くようにした

kaminariにした理由: `Kaminari.paginate_array`でActiveRecord以外のものについてもページングが行えるため(#102 )