### PR TITLE
userを変換する関数をコンパクトにした(#75の後続)

### DIFF
--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -70,19 +70,17 @@ RSpec.describe 'User' do
 
       context 'アクセストークンが有効期限内の場合' do
         before do
-          def users_to_json(users)
-            users.map do |user|
-              {
-                id:           user.id,
-                name:         user.name,
-                email:        user.email,
-                admin:        user.admin,
-                activated:    user.activated,
-                activated_at: user.activated_at&.iso8601(2),
-                created_at:   user.created_at.iso8601(2),
-                updated_at:   user.updated_at.iso8601(2)
-              }
-            end.to_json
+          def user_to_api_user(user)
+            {
+              id:           user.id,
+              name:         user.name,
+              email:        user.email,
+              admin:        user.admin,
+              activated:    user.activated,
+              activated_at: user.activated_at&.iso8601(2),
+              created_at:   user.created_at.iso8601(2),
+              updated_at:   user.updated_at.iso8601(2)
+            }
           end
           WebMock
             .stub_request(:get, 'http://localhost:3000/api/users')
@@ -91,12 +89,11 @@ RSpec.describe 'User' do
               headers: { Authorization: "Bearer #{access_token}" }
             )
             .to_return(
-              body:    users_to_json(
-                User
-                  .order(sort_key => order_by)
-                  .limit(limit)
-                  .offset(offset)
-              ),
+              body:    User
+                       .order(sort_key => order_by)
+                       .limit(limit)
+                       .offset(offset).map { |user| user_to_api_user(user) }
+                       .to_json,
               status:  200,
               headers: { 'Content-Type' => 'application/json' }
             )


### PR DESCRIPTION
## やったこと

https://github.com/sls-training/2023-rails-sample/pull/75#discussion_r1230521014 を受けてリファクタリングを行った
usersの配列単位で変換するのではなくuserの単位で変換できるようにした


## 思っていること

- 関数名が絶対良くないとは思うが、思いつかないこと(userが3回も出てきてるのはくどくて読みにくそう)
- activated_at&.iso8601(2)と変換していたが、そもそもAPIとしてデータを不可逆な形で出力することは間違っていると思ったこと。

## 備考
#75 の後続