### PR TITLE
スペック内でAPIが呼ばれているかどうかをテストするように変更(#75の後続)

### DIFF
--- a/spec/models/api/access_token_spec.rb
+++ b/spec/models/api/access_token_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'AccessToken' do
 
         it 'errorが返る' do
           expect(subject).to include Api::Error
+          expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                               .with(body: { email:, password: })
         end
       end
 
@@ -60,6 +62,8 @@ RSpec.describe 'AccessToken' do
 
           it 'errorが返る' do
             expect(subject).to include Api::Error
+            expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                                 .with(body: { email:, password: })
           end
         end
 
@@ -85,6 +89,8 @@ RSpec.describe 'AccessToken' do
 
           it 'errorが返る' do
             expect(subject).to include Api::Error
+            expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                                 .with(body: { email:, password: })
           end
         end
       end
@@ -116,6 +122,8 @@ RSpec.describe 'AccessToken' do
 
         it 'errorが返る' do
           expect(subject).to include Api::Error
+          expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                               .with(body: { email:, password: })
         end
       end
 
@@ -144,6 +152,8 @@ RSpec.describe 'AccessToken' do
 
           it 'errorが返る' do
             expect(subject).to include Api::Error
+            expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                                 .with(body: { email:, password: })
           end
         end
 
@@ -164,6 +174,8 @@ RSpec.describe 'AccessToken' do
 
           it 'アクセストークンが返る' do
             expect(subject.value).not_to be_nil
+            expect(WebMock).to have_requested(:post, 'http://localhost:3000/api/token')
+                                 .with(body: { email:, password: })
           end
         end
       end

--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe 'User' do
 
       it 'errorsが返る' do
         expect(subject).to include Api::Error
+        expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
+                             .with(query: { limit:, offset:, order_by:, sort_key: })
       end
     end
 
@@ -65,6 +67,11 @@ RSpec.describe 'User' do
 
         it 'errorsが返る' do
           expect(subject).to include Api::Error
+          expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
+                               .with(
+                                 query:   { limit:, offset:, order_by:, sort_key: },
+                                 headers: { Authorization: "Bearer #{access_token}" }
+                               )
         end
       end
 
@@ -106,6 +113,11 @@ RSpec.describe 'User' do
 
         it 'ユーザの配列が返る' do
           expect(subject).to include Api::User
+          expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
+                               .with(
+                                 query:   { limit:, offset:, order_by:, sort_key: },
+                                 headers: { Authorization: "Bearer #{access_token}" }
+                               )
         end
       end
     end


### PR DESCRIPTION
## やったこと
https://github.com/sls-training/2023-rails-sample/pull/75#discussion_r1230519044 を受けて
`models/api/access_token_spec.rb`と`models/api/users_spec.rb`のスペック内でAPIが呼ばれているかどうかをテストするように変更


WebMockのhave_requestedで呼ばれているかどうかを確認するようにした

## 備考
#75 の後続