### PR TITLE
管理画面でユーザを更新するcontrollerの仕様を作成した

### DIFF
--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -106,4 +106,62 @@ RSpec.describe 'AdminUsers' do
       end
     end
   end
+
+  describe 'PATCH /admin/users/:id' do
+    context 'ログインしていない場合' do
+      xit 'ログインページにリダイレクトしてトーストメッセージを表示' do
+        # TODO: specの内容を作成する
+      end
+    end
+
+    context 'ログインしている場合' do
+      context 'ユーザが管理者ではない場合' do
+        xit 'ログインページにリダイレクトしてトーストメッセージを表示' do
+          # TODO: specの内容を作成する
+        end
+      end
+
+      context 'ユーザが管理者の場合' do
+        xit 'ユーザ更新用のAPIを呼んでいること' do
+          # TODO: specの内容を作成する
+        end
+
+        context '不正なユーザーデータが指定された場合' do
+          xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
+            # TODO: specの内容を作成する
+          end
+        end
+
+        context '正当なユーザーデータが指定された場合' do
+          context '更新するパラメータにpasswordがない場合' do
+            xit '編集に成功した旨をトーストメッセージで表示して、200を返す' do
+              # TODO: specの内容を作成する
+            end
+          end
+
+          context '更新するパラメータにpasswordがある場合' do
+            context 'パラメータにpassword_confirmationがない場合' do
+              xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
+                # TODO: specの内容を作成する
+              end
+            end
+
+            context 'パラメータにpassword_confirmationがある場合' do
+              context 'passwordとpassword_confirmationの値が違う場合' do
+                xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
+                  # TODO: specの内容を作成する
+                end
+              end
+
+              context 'passwordとpassword_confirmationの値が同じ場合' do
+                xit '編集に成功した旨をトーストメッセージで表示して、200を返す' do
+                  # TODO: specの内容を作成する
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe 'AdminUsers' do
           # TODO: specの内容を作成する
         end
 
-        context '不正なユーザーデータが指定された場合' do
+        context 'APIサーバからエラーが返ってきた場合' do
           xit 'ユーザ管理画面にリダイレクトして、作成に失敗した旨をトーストメッセージで表示する' do
             # TODO: specの内容を作成する
           end
         end
 
-        context '正当なユーザーデータが指定された場合' do
+        context 'APIサーバから成功が返ってきた場合' do
           xit 'ユーザ管理画面にリダイレクトして、作成に成功した旨をトーストメッセージで表示する' do
             # TODO: specの内容を作成する
           end
@@ -126,13 +126,13 @@ RSpec.describe 'AdminUsers' do
           # TODO: specの内容を作成する
         end
 
-        context '不正なユーザーデータが指定された場合' do
+        context 'APIサーバからエラーが返ってきた場合' do
           xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
             # TODO: specの内容を作成する
           end
         end
 
-        context '正当なユーザーデータが指定された場合' do
+        context 'APIサーバから成功が返ってきた場合' do
           context '更新するパラメータにpasswordがない場合' do
             xit '編集に成功した旨をトーストメッセージで表示して、200を返す' do
               # TODO: specの内容を作成する

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -138,28 +138,6 @@ RSpec.describe 'AdminUsers' do
               # TODO: specの内容を作成する
             end
           end
-
-          context '更新するパラメータにpasswordがある場合' do
-            context 'パラメータにpassword_confirmationがない場合' do
-              xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
-                # TODO: specの内容を作成する
-              end
-            end
-
-            context 'パラメータにpassword_confirmationがある場合' do
-              context 'passwordとpassword_confirmationの値が違う場合' do
-                xit 'ユーザ管理画面にリダイレクトして、編集に失敗した旨をトーストメッセージで表示' do
-                  # TODO: specの内容を作成する
-                end
-              end
-
-              context 'passwordとpassword_confirmationの値が同じ場合' do
-                xit '編集に成功した旨をトーストメッセージで表示して、200を返す' do
-                  # TODO: specの内容を作成する
-                end
-              end
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
## やったこと
ユーザ管理用アプリで、ユーザを更新するcontroller部分のspecを作成した(仕様: #53 )
(admin/users_controller.rbのupdate関数部分)

テストで担保すること
- 管理者ユーザでログインしていること
- 不正なパラメーターだった場合、ユーザ管理画面にリダイレクトして、失敗した旨をトーストで表示すること
- 正当なパラメータだった場合に、ユーザ管理画面にリダイレクトして、成功した旨をトーストで表示すること
- ユーザ更新のAPIを呼んでいること