### PR TITLE
ユーザ作成のAPIを呼ぶ関数の仕様を作成

### DIFF
--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -121,7 +121,14 @@ RSpec.describe 'User' do
       end
 
       context 'アクセストークンが有効期限内の場合' do
-        xit 'ユーザ作成のAPIを呼び、作成されたユーザを返す' do
+        context '不正なユーザーデータが指定された場合' do
+          xit 'ユーザ作成のAPIを呼び、例外を返す' do
+          end
+        end
+
+        context '正当なユーザーデータが指定された場合' do
+          xit 'ユーザ作成のAPIを呼び、作成されたユーザを返す' do
+          end
         end
       end
     end

--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -107,4 +107,23 @@ RSpec.describe 'User' do
       end
     end
   end
+
+  describe '#create' do
+    context 'アクセストークンがない場合' do
+      xit 'ユーザ作成のAPIを呼び、例外を返す' do
+      end
+    end
+
+    context 'アクセストークンがある場合' do
+      context 'アクセストークンが有効期限切れの場合' do
+        xit 'ユーザ作成のAPIを呼び、例外を返す' do
+        end
+      end
+
+      context 'アクセストークンが有効期限内の場合' do
+        xit 'ユーザ作成のAPIを呼び、作成されたユーザを返す' do
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
ユーザ作成のAPIを呼ぶための関数のspecを作成した

テストで担保すること
- アクセストークンが正当かつ作成に使うパラメータも正しい場合、ユーザを返すこと
- それ以外の失敗した場合で例外を返すこと