### PR TITLE
ユーザ削除のAPIを呼ぶ関数を実装(#113の後続)

### DIFF
--- a/app/models/api/user.rb
+++ b/app/models/api/user.rb
@@ -32,6 +32,14 @@ module Api
         end
       end
 
+      def destroy(access_token:, id:)
+        headers = { 'Authorization' => "Bearer #{access_token}" }
+        response = delete("/users/#{id}", headers:)
+        return true if response.is_a?(Net::HTTPNoContent)
+
+        raise Api::Error.from_json(JSON.parse(response.body, symbolize_names: true)[:errors])
+      end
+
       def from_json(json)
         id, name, email, admin, activated, activated_at, created_at, updated_at = json.values_at(
           :id, :name, :email, :admin,

--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -109,25 +109,111 @@ RSpec.describe 'User' do
   end
 
   describe '#destroy' do
+    subject { Api::User.destroy(access_token:, id:) }
+
+    let(:target_user)  { create(:user) }
+    let(:current_user) { create(:user, :admin) }
+
     context 'アクセストークンがない場合' do
-      xit 'ユーザ削除のAPIを呼び、例外を返す' do
+      let(:access_token) { nil }
+      let(:id) { target_user.id }
+
+      before do
+        WebMock
+          .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+          .to_return(
+            body:   {
+              errors: [
+                {
+                  name:    'access_token',
+                  message: 'authentication token is missing'
+                }
+              ]
+            }.to_json,
+            status: 400
+          )
+      end
+
+      it 'ユーザ削除のAPIを呼び、例外を返す' do
+        expect { subject }.to raise_error Api::Error
+        expect(WebMock).to have_requested(:delete, "http://localhost:3000/api/users/#{id}")
       end
     end
 
     context 'アクセストークンがある場合' do
       context 'アクセストークンが有効期限切れの場合' do
-        xit 'ユーザ削除のAPIを呼び、例外を返す' do
+        let(:access_token) { expired_access_token(email: current_user.email) }
+        let(:id) { target_user.id }
+
+        before do
+          WebMock
+            .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+            .with(headers: { Authorization: "Bearer #{access_token}" })
+            .to_return(
+              body:   {
+                errors: [
+                  {
+                    token:   'access_token',
+                    message: 'Invalid token'
+                  }
+                ]
+              }.to_json,
+              status: 401
+            )
+        end
+
+        it 'ユーザ削除のAPIを呼び、例外を返す' do
+          expect { subject }.to raise_error Api::Error
+          expect(WebMock).to have_requested(:delete, "http://localhost:3000/api/users/#{id}")
         end
       end
 
       context 'アクセストークンが有効期限内の場合' do
+        let(:access_token) { AccessToken.new(email: current_user.email).encode }
+
         context '不正なユーザーidが指定された場合' do
-          xit 'ユーザ削除のAPIを呼び、例外を返す' do
+          let(:id) { current_user.id }
+
+          before do
+            WebMock
+              .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+              .with(headers: { Authorization: "Bearer #{access_token}" })
+              .to_return(
+                body:   {
+                  errors: [
+                    {
+                      name:    'user_id',
+                      message: "You can't delete yourself"
+                    }
+                  ]
+                }.to_json,
+                status: 401
+              )
+          end
+
+          it 'ユーザ削除のAPIを呼び、例外を返す' do
+            expect { subject }.to raise_error Api::Error
+            expect(WebMock).to have_requested(:delete, "http://localhost:3000/api/users/#{id}")
+                                 .with(headers: { Authorization: "Bearer #{access_token}" })
           end
         end
 
         context '正当なユーザーidが指定された場合' do
-          xit 'ユーザ削除のAPIを呼び、trueを返す' do
+          let(:id) { target_user.id }
+
+          before do
+            WebMock
+              .stub_request(:delete, "http://localhost:3000/api/users/#{id}")
+              .with(headers: { Authorization: "Bearer #{access_token}" })
+              .to_return(
+                status: 204
+              )
+          end
+
+          it 'ユーザ削除のAPIを呼び、trueを返す' do
+            expect(subject).to be_truthy
+            expect(WebMock).to have_requested(:delete, "http://localhost:3000/api/users/#{id}")
+                                 .with(headers: { Authorization: "Bearer #{access_token}" })
           end
         end
       end


### PR DESCRIPTION
## やったこと
ユーザ削除のAPIを呼ぶための関数を実装した(spec: #113 )
成功した場合trueを返し、 失敗するとApi::Errorの例外を発生させるようにした

備考
#113 の後続

#99  のPRを再度作り直した