### PR TITLE
トーストメッセージを確認するspecの修正

### DIFF
--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'AdminUsers' do
       it 'ログインページにリダイレクトしてトーストメッセージを表示' do
         expect(subject).to redirect_to login_url
         expect(response).to have_http_status :see_other
-        expect(flash[:danger]).not_to be_nil
+        expect(flash[:danger]).to be_present
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe 'AdminUsers' do
       it 'ログインページにリダイレクトしてトーストメッセージを表示' do
         expect(subject).to redirect_to login_url
         expect(response).to have_http_status :see_other
-        expect(flash[:danger]).not_to be_nil
+        expect(flash[:danger]).to be_present
       end
     end
   end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'AdminUsers' do
       context 'ユーザが管理者ではない場合' do
         before { log_in_as(non_admin_user) }
 
-        it 'ログインページにリダイレクトしてトーストメッセージを表示' do
+        it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
           expect(subject).to redirect_to login_url
           expect(response).to have_http_status :see_other
           expect(flash[:danger]).to be_present


### PR DESCRIPTION
# やったこと
https://github.com/sls-training/2023-rails-sample/pull/106#discussion_r1237889635 を受けて`not_to be_nil`で確認していた箇所を`be_present`に変更した

(すぐ修正できそうなPRにはminorタグをつけることにしました)