### PR TITLE
自分のメールアドレスかどうかも検証するように変更

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -47,9 +47,9 @@ module Api
     end
 
     def update
-      ## ユーザがすでに存在している時
+      ## 自分以外のメールアドレスとしてすでに登録されている場合
       email = user_params[:email]
-      if email && ::User.exists?(email:)
+      if email && email != user.email && ::User.exists?(email:)
         errors = [{ name: 'email', message: t('.exist_user') }]
         render 'api/errors', locals: { errors: }, status: :unprocessable_entity and return
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe 'ApiUsers' do
             end
           end
 
-          context 'emailのユーザが存在しない場合' do
+          context 'emailのユーザが存在しない、もしくは自分のメールアドレスの場合' do
             let(:params) { { email: Faker::Internet.email } }
 
             it '200が返って、編集したユーザを返すこと' do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe 'ApiUsers' do
         end
 
         context '正しいユーザーデータが指定された場合' do
-          context 'emailがすでに存在するユーザのemailの場合' do
+          context 'emailが自分以外のメールアドレスとしてすでに登録されている場合' do
             let(:params) { { email: user.email } }
 
             it '422が返って、エラーメッセージを返すこと' do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -510,16 +510,7 @@ RSpec.describe 'ApiUsers' do
         end
 
         context '正しいユーザーデータが指定された場合' do
-          context 'emailが自分以外のメールアドレスとしてすでに登録されている場合' do
-            let(:params) { { email: user.email } }
-
-            it '422が返って、エラーメッセージを返すこと' do
-              expect(subject).to have_http_status :unprocessable_entity
-              expect(subject.parsed_body).to have_key('errors')
-            end
-          end
-
-          context 'emailのユーザが存在しない、もしくは自分のメールアドレスの場合' do
+          context 'emailののユーザが存在しない場合' do
             let(:params) { { email: Faker::Internet.email } }
 
             it '200が返って、編集したユーザを返すこと' do
@@ -527,6 +518,28 @@ RSpec.describe 'ApiUsers' do
               expect(subject.parsed_body).to include(
                 *%w[id name admin activated activated_at created_at updated_at]
               )
+            end
+          end
+
+          context 'emailのユーザが存在する場合' do
+            context 'emailのユーザが自分以外の場合' do
+              let(:params) { { email: user.email } }
+
+              it '422が返って、エラーメッセージを返すこと' do
+                expect(subject).to have_http_status :unprocessable_entity
+                expect(subject.parsed_body).to have_key('errors')
+              end
+            end
+
+            context 'emailのユーザが自分の場合' do
+              let(:params) { { email: target_user.email } }
+
+              it '200が返って、編集したユーザを返すこと' do
+                expect(subject).to be_successful
+                expect(subject.parsed_body).to include(
+                  *%w[id name admin activated activated_at created_at updated_at]
+                )
+              end
             end
           end
         end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe 'ApiUsers' do
         end
 
         context '正しいユーザーデータが指定された場合' do
-          context 'emailののユーザが存在しない場合' do
+          context 'emailのユーザが存在しない場合' do
             let(:params) { { email: Faker::Internet.email } }
 
             it '200が返って、編集したユーザを返すこと' do


### PR DESCRIPTION
## やったこと
https://github.com/sls-training/2023-rails-sample/pull/93#discussion_r1237915502 から
自分のメールアドレスであれば問題はないので
自分以外のメールアドレスとしてすでに登録されている場合、エラーを返すように変更。

コード変更内容としては`email != user.email`を追加して、specのitのテキストだけ変更しました