### PR TITLE
管理者用ページでユーザを一覧表示できるように変更した

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,6 +18,10 @@ module Admin
 
       total_count = (user_count / DISPLAY_AMOUNT) * DISPLAY_AMOUNT
       @users = Kaminari.paginate_array(user_list, total_count:).page(params[:page]).per(DISPLAY_AMOUNT)
+    rescue Api::Error => e
+      redirect_to root_url, status: :see_other, flash: {
+        danger: JSON.parse(e.message).map { |error| "#{error['name']} : #{error['message']}" }.join('\n')
+      }
     rescue StandardError => e
       redirect_to root_url, status: :see_other, flash: { danger: e.message }
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,7 +11,7 @@ module Admin
       user_count = User.count
 
       user_list = Api::User.get_list(
-        access_token:,
+        access_token: raw_access_token,
         limit:        DISPLAY_AMOUNT,
         offset:       DISPLAY_AMOUNT * [(params[:page].to_i - 1), 0].max
       )

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,17 +9,17 @@ module Admin
     def index
       # TODO: ユーザのcountをAPIから取得できるようにすること
       user_count = User.count
-      begin
-        user_list = Api::User.get_list(
-          access_token:,
-          limit:        DISPLAY_AMOUNT,
-          offset:       DISPLAY_AMOUNT * [(params[:page].to_i - 1), 0].max
-        )
-      rescue StandardError => e
-        redirect_to root_url, status: :see_other, flash: { danger: e.message } and return
-      end
+
+      user_list = Api::User.get_list(
+        access_token:,
+        limit:        DISPLAY_AMOUNT,
+        offset:       DISPLAY_AMOUNT * [(params[:page].to_i - 1), 0].max
+      )
+
       total_count = (user_count / DISPLAY_AMOUNT) * DISPLAY_AMOUNT
       @users = Kaminari.paginate_array(user_list, total_count:).page(params[:page]).per(DISPLAY_AMOUNT)
+    rescue StandardError => e
+      redirect_to root_url, status: :see_other, flash: { danger: e.message }
     end
 
     def create

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -20,7 +20,7 @@ module Admin
       @users = Kaminari.paginate_array(user_list, total_count:).page(params[:page]).per(DISPLAY_AMOUNT)
     rescue Api::Error => e
       redirect_to root_url, status: :see_other, flash: {
-        danger: JSON.parse(e.message).map { |error| "#{error['name']} : #{error['message']}" }.join('\n')
+        danger: e.errors.map { |error| "#{error[:name]} : #{error[:message]}" }.join('\n')
       }
     rescue StandardError => e
       redirect_to root_url, status: :see_other, flash: { danger: e.message }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,11 +4,22 @@ module Admin
   class UsersController < ApplicationController
     before_action :require_logged_in
     before_action :require_access_token
-
+    DISPLAY_AMOUNT = 10 # 表示数
     # GET /admin/users
     def index
-      # TODO: ユーザAPIを使ったものに後から置き換えること
-      @users = User.page(params[:page]).per(30)
+      # TODO: ユーザのcountをAPIから取得できるようにすること
+      user_count = User.count
+      begin
+        user_list = Api::User.get_list(
+          access_token:,
+          limit:        DISPLAY_AMOUNT,
+          offset:       DISPLAY_AMOUNT * [(params[:page].to_i - 1), 0].max
+        )
+      rescue StandardError => e
+        redirect_to root_url, status: :see_other, flash: { danger: e.message } and return
+      end
+      total_count = (user_count / DISPLAY_AMOUNT) * DISPLAY_AMOUNT
+      @users = Kaminari.paginate_array(user_list, total_count:).page(params[:page]).per(DISPLAY_AMOUNT)
     end
 
     def create

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -21,7 +21,11 @@ module SessionsHelper
   end
 
   def verify_access_token?
-    Api::AccessToken.new(value: cookies[:access_token]).valid?
+    Api::AccessToken.new(value: access_token).valid?
+  end
+
+  def access_token
+    cookies[:access_token]
   end
 
   # 変数とかをメソッドで管理する感じ

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -21,10 +21,10 @@ module SessionsHelper
   end
 
   def verify_access_token?
-    Api::AccessToken.new(value: access_token).valid?
+    Api::AccessToken.new(value: raw_access_token).valid?
   end
 
-  def access_token
+  def raw_access_token
     cookies[:access_token]
   end
 

--- a/app/models/api/access_token.rb
+++ b/app/models/api/access_token.rb
@@ -16,7 +16,7 @@ module Api
         value = data[:access_token]
         new(value:)
       else
-        raise Api::Error.from_json(data[:errors])
+        raise Api::Error.from_json(data[:errors].to_json)
       end
     end
 

--- a/app/models/api/access_token.rb
+++ b/app/models/api/access_token.rb
@@ -16,7 +16,7 @@ module Api
         value = data[:access_token]
         new(value:)
       else
-        raise Api::Error.from_json(data[:errors].to_json)
+        raise Api::Error, data[:errors]
       end
     end
 

--- a/app/models/api/error.rb
+++ b/app/models/api/error.rb
@@ -2,8 +2,11 @@
 
 module Api
   class Error < StandardError
-    def self.from_json(json)
-      Api::Error.new(json)
+    attr_reader :errors
+
+    def initialize(errors)
+      super('')
+      @errors = errors
     end
   end
 end

--- a/app/models/api/user.rb
+++ b/app/models/api/user.rb
@@ -28,7 +28,7 @@ module Api
           end
 
         else
-          raise Api::Error.from_json(users[:errors])
+          raise Api::Error.from_json(users[:errors].to_json)
         end
       end
 

--- a/app/models/api/user.rb
+++ b/app/models/api/user.rb
@@ -28,7 +28,7 @@ module Api
           end
 
         else
-          raise Api::Error.from_json(users[:errors].to_json)
+          raise Api::Error, users[:errors]
         end
       end
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -41,22 +41,22 @@
               <tbody>
                 <% @users.each do | user | %>
                 <tr>
-                  <td scope="row"><%= user[:id] %></td>
-                  <td><%= user[:name] %></td>
-                  <td><%= user[:email] %></td>
+                  <td scope="row"><%= user.id %></td>
+                  <td><%= user.name %></td>
+                  <td><%= user.email %></td>
                   <td>
-                    <% if user[:admin] %>
+                    <% if user.admin %>
                     <i class="fa-solid fa-check"></i>
                     <% end %>
                   </td>
                   <td>
-                    <% if user[:activated_at] %>
+                    <% if user.activated_at %>
                     <i class="fa-solid fa-check"></i>
                     <% end %>
                   </td>
-                  <td><%= user[:activated_at]&.strftime("%Y/%m/%d %H:%M:%S") %></td>
-                  <td><%= user[:created_at].strftime("%Y/%m/%d %H:%M:%S") %></td>
-                  <td><%= user[:updated_at].strftime("%Y/%m/%d %H:%M:%S") %></td>
+                  <td><%= user.activated_at&.to_datetime.strftime("%Y/%m/%d %H:%M:%S") %></td>
+                  <td><%= user.created_at.to_datetime.strftime("%Y/%m/%d %H:%M:%S") %></td>
+                  <td><%= user.updated_at.to_datetime.strftime("%Y/%m/%d %H:%M:%S") %></td>
                   <td class="d-flex flex-row justify-content-between">
                     <%= button_tag "編集",
                         id:"edit-user-button", 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe 'AdminUsers' do
   let!(:non_admin_user) { create(:user, :noadmin) }
 
   describe 'GET /admin/users' do
-    subject { get admin_users_path, params: { page: defined?(page) ? page : nil }.compact }
+    subject do
+      get admin_users_path, params: { page: defined?(page) ? page : nil }.compact
+      response
+    end
 
     context 'ログインしていない場合' do
       it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
@@ -80,7 +83,7 @@ RSpec.describe 'AdminUsers' do
 
             it 'ステータスコード200とともに、10件分のユーザーを表示する' do
               subject
-              expect(response).to be_successful
+              expect(subject).to be_successful
               users = controller.instance_variable_get(:@users)
               expect(users.count).to be 10
             end
@@ -96,8 +99,7 @@ RSpec.describe 'AdminUsers' do
               end
 
               it 'ステータスコード200とともに、10件分のユーザーを表示する' do
-                subject
-                expect(response).to be_successful
+                expect(subject).to be_successful
                 users = controller.instance_variable_get(:@users)
                 expect(users.count).to be 10
               end
@@ -112,8 +114,7 @@ RSpec.describe 'AdminUsers' do
               end
 
               it 'ステータスコード200とともに、10件分のユーザーを表示する' do
-                subject
-                expect(response).to be_successful
+                expect(subject).to be_successful
                 users = controller.instance_variable_get(:@users)
                 expect(users.count).to be 10
               end
@@ -128,8 +129,7 @@ RSpec.describe 'AdminUsers' do
               end
 
               it 'ステータスコード200とともに、10件分のユーザーを表示する' do
-                subject
-                expect(response).to be_successful
+                expect(subject).to be_successful
                 users = controller.instance_variable_get(:@users)
                 expect(users.count).to be 10
               end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -6,7 +6,31 @@ RSpec.describe 'AdminUsers' do
   let!(:non_admin_user) { create(:user, :noadmin) }
 
   describe 'GET /admin/users' do
+    context 'ログインしていない場合' do
+      subject { get admin_users_path }
+
+      it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
+        expect(subject).to redirect_to login_url
+        expect(response).to have_http_status :see_other
+        expect(flash[:danger]).not_to be_nil
+      end
+    end
+
     context 'ログインしている場合' do
+      context 'ユーザが管理者ではない場合' do
+        subject { get admin_users_path }
+
+        let(:non_admin_user) { create(:user, :noadmin) }
+
+        before { log_in_as(non_admin_user) }
+
+        it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
+          expect(subject).to redirect_to login_url
+          expect(response).to have_http_status :see_other
+          expect(flash[:danger]).not_to be_nil
+        end
+      end
+
       context 'ユーザが管理者の場合' do
         let(:order_by) { 'asc' }
         let(:sort_key) { 'name' }
@@ -116,30 +140,6 @@ RSpec.describe 'AdminUsers' do
             end
           end
         end
-      end
-
-      context 'ユーザが管理者ではない場合' do
-        subject { get admin_users_path }
-
-        let(:non_admin_user) { create(:user, :noadmin) }
-
-        before { log_in_as(non_admin_user) }
-
-        it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
-          expect(subject).to redirect_to login_url
-          expect(response).to have_http_status :see_other
-          expect(flash[:danger]).not_to be_nil
-        end
-      end
-    end
-
-    context 'ログインしていない場合' do
-      subject { get admin_users_path }
-
-      it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
-        expect(subject).to redirect_to login_url
-        expect(response).to have_http_status :see_other
-        expect(flash[:danger]).not_to be_nil
       end
     end
   end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'AdminUsers' do
   let!(:non_admin_user) { create(:user, :noadmin) }
 
   describe 'GET /admin/users' do
-    context 'ログインしていない場合' do
-      subject { get admin_users_path }
+    subject { get admin_users_path, params: { page: defined?(page) ? page : nil }.compact }
 
+    context 'ログインしていない場合' do
       it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
         expect(subject).to redirect_to login_url
         expect(response).to have_http_status :see_other
@@ -18,8 +18,6 @@ RSpec.describe 'AdminUsers' do
 
     context 'ログインしている場合' do
       context 'ユーザが管理者ではない場合' do
-        subject { get admin_users_path }
-
         let(:non_admin_user) { create(:user, :noadmin) }
 
         before { log_in_as(non_admin_user) }
@@ -45,8 +43,6 @@ RSpec.describe 'AdminUsers' do
         end
 
         context '例外が返ってきた場合' do
-          subject { get admin_users_path }
-
           before { allow(Api::User).to receive(:get_list).and_raise(StandardError) }
 
           it 'ホーム画面にリダイレクトして、取得に失敗した旨をトーストメッセージで表示する' do
@@ -77,8 +73,6 @@ RSpec.describe 'AdminUsers' do
           end
 
           context 'クエリパラメータにpageがない場合' do
-            subject { get admin_users_path }
-
             it 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
               subject
               expect(Api::User).to have_received(:get_list).with(access_token:, limit:, offset: 0)
@@ -93,8 +87,6 @@ RSpec.describe 'AdminUsers' do
           end
 
           context 'クエリパラメータにpageがある場合' do
-            subject { get admin_users_path, params: { page: } }
-
             context 'pageの値が0の場合' do
               let(:page) { 0 }
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -62,8 +62,14 @@ RSpec.describe 'AdminUsers' do
             user_list = create_list(:user, 20)
             api_users = user_list.take(limit).map do |user|
               Api::User.new(
-                id: user.id, name: user.name, email: user.email, admin: user.admin, activated: user.activated,
-                activated_at: user.activated_at, created_at: user.created_at, updated_at: user.updated_at
+                id:           user.id,
+                name:         user.name,
+                email:        user.email,
+                admin:        user.admin,
+                activated:    user.activated,
+                activated_at: user.activated_at&.iso8601(2),
+                created_at:   user.created_at.iso8601(2),
+                updated_at:   user.updated_at.iso8601(2)
               )
             end
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -47,8 +47,6 @@ RSpec.describe 'AdminUsers' do
         context '例外が返ってきた場合' do
           subject { get admin_users_path }
 
-          let(:offset) { 0 }
-
           before { allow(Api::User).to receive(:get_list).and_raise(StandardError) }
 
           it 'ホーム画面にリダイレクトして、取得に失敗した旨をトーストメッセージで表示する' do

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe 'AdminUsers' do
 
   describe 'GET /admin/users' do
     subject do
-      get admin_users_path, params: { page: defined?(page) ? page : nil }.compact
+      get admin_users_path, params: { page: }.compact
       response
     end
+
+    let(:page) { nil }
 
     context 'ログインしていない場合' do
       it 'ログインページにリダイレクトしてトーストメッセージを表示する' do

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -6,54 +6,112 @@ RSpec.describe 'AdminUsers' do
   let!(:non_admin_user) { create(:user, :noadmin) }
 
   describe 'GET /admin/users' do
-    subject { get admin_users_path }
-
     context 'ログインしている場合' do
       context 'ユーザが管理者の場合' do
+        let(:order_by) { 'asc' }
+        let(:sort_key) { 'name' }
+        let(:limit) { 10 }
+        let(:access_token) { AccessToken.new(email: admin_user.email).encode }
+        let(:admin_user) { create(:user, :admin) }
+
+        before do
+          allow(Api::AccessToken).to receive(:create).and_return(Api::AccessToken.new(value: access_token))
+          post login_path,
+               params: { session: { email: admin_user.email, password: admin_user.password, remember_me: '1' } }
+        end
+
         context 'ユーザー取得の関数の実行時に例外が返ってきた場合' do
-          xit 'ホーム画面にリダイレクトして、取得に失敗した旨をトーストメッセージで表示する' do
-            # TODO: specの内容を作成する
+          subject { get admin_users_path }
+
+          let(:offset) { 0 }
+
+          before { allow(Api::User).to receive(:get_list).and_raise(StandardError) }
+
+          it 'ホーム画面にリダイレクトして、取得に失敗した旨をトーストメッセージで表示する' do
+            expect(subject).to redirect_to root_url
+            expect(Api::User).to have_received(:get_list)
+            expect(response).to have_http_status :see_other
+            expect(flash[:danger]).to be_present
           end
         end
 
         context 'ユーザー取得の関数の実行時にユーザの配列が返ってきた場合' do
-          context 'クエリパラメータにpageがない場合' do
-            xit 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
-              # TODO: specの内容を作成する
+          before do
+            user_list = create_list(:user, 20)
+            api_users = user_list.take(limit).map do |user|
+              Api::User.new(
+                id: user.id, name: user.name, email: user.email, admin: user.admin, activated: user.activated,
+                activated_at: user.activated_at, created_at: user.created_at, updated_at: user.updated_at
+              )
             end
 
-            xit 'ステータスコード200とともに、10件分のユーザーを表示する' do
-              # TODO: specの内容を作成する
+            allow(Api::User).to receive(:get_list).and_return(api_users)
+          end
+
+          context 'クエリパラメータにpageがない場合' do
+            subject { get admin_users_path }
+
+            it 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
+              subject
+              expect(Api::User).to have_received(:get_list).with(access_token:, limit:, offset: 0)
+            end
+
+            it 'ステータスコード200とともに、10件分のユーザーを表示する' do
+              subject
+              expect(response).to be_successful
+              users = controller.instance_variable_get(:@users)
+              expect(users.count).to be 10
             end
           end
 
           context 'クエリパラメータにpageがある場合' do
+            subject { get admin_users_path, params: { page: } }
+
             context 'pageの値が0の場合' do
-              xit 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
-                # TODO: specの内容を作成する
+              let(:page) { 0 }
+
+              it 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
+                subject
+                expect(Api::User).to have_received(:get_list).with(access_token:, limit:, offset: 0)
               end
 
-              xit 'ステータスコード200とともに、10件分のユーザーを表示する' do
-                # TODO: specの内容を作成する
+              it 'ステータスコード200とともに、10件分のユーザーを表示する' do
+                subject
+                expect(response).to be_successful
+                users = controller.instance_variable_get(:@users)
+                expect(users.count).to be 10
               end
             end
 
             context 'pageの値が1の場合' do
-              xit 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出す' do
-                # TODO: specの内容を作成する
+              let(:page) { 1 }
+
+              it 'ユーザー取得の関数にoffset=0パラメータをつけて呼び出すこと' do
+                subject
+                expect(Api::User).to have_received(:get_list).with(access_token:, limit:, offset: 0)
               end
 
-              xit 'ステータスコード200とともに、10件分のユーザーを表示する' do
+              it 'ステータスコード200とともに、10件分のユーザーを表示する' do
+                subject
+                expect(response).to be_successful
+                users = controller.instance_variable_get(:@users)
+                expect(users.count).to be 10
               end
             end
 
             context 'pageの値が2の場合' do
-              xit 'ユーザー取得の関数にoffset=10パラメータをつけて呼び出す' do
-                # TODO: specの内容を作成する
+              let(:page) { 2 }
+
+              it 'ユーザー取得APIにoffset=10パラメータをつけて呼び出すこと' do
+                subject
+                expect(Api::User).to have_received(:get_list).with(access_token:, limit:, offset: 10)
               end
 
-              xit 'ステータスコード200とともに、10件分のユーザーを表示する' do
-                # TODO: specの内容を作成する
+              it 'ステータスコード200とともに、10件分のユーザーを表示する' do
+                subject
+                expect(response).to be_successful
+                users = controller.instance_variable_get(:@users)
+                expect(users.count).to be 10
               end
             end
           end
@@ -61,6 +119,10 @@ RSpec.describe 'AdminUsers' do
       end
 
       context 'ユーザが管理者ではない場合' do
+        subject { get admin_users_path }
+
+        let(:non_admin_user) { create(:user, :noadmin) }
+
         before { log_in_as(non_admin_user) }
 
         it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
@@ -72,6 +134,8 @@ RSpec.describe 'AdminUsers' do
     end
 
     context 'ログインしていない場合' do
+      subject { get admin_users_path }
+
       it 'ログインページにリダイレクトしてトーストメッセージを表示する' do
         expect(subject).to redirect_to login_url
         expect(response).to have_http_status :see_other


### PR DESCRIPTION
## やったこと

- ユーザ管理用アプリで、ユーザを取得する部分のspec(#120 で修正したものの)の内容を作成した
- ユーザ管理用アプリで、ユーザを取得するcontrollerの部分を作成した
(admin/users_controller.rbのindex)
ページネーションにはKaminari.paginate_arrayを用いた

- viewの修正
 Api::Userを表示できるように変更した

- アクセストークンをcookieから取得できるようにした

## 備考
今回のPRで考えないこと
- ユーザの数を使いたかったのでユーザの全体数をUser.count使っているが、別のPRでユーザ数を取得するAPIを作成し、そちらに置き換える