### PR TITLE
ユーザ取得のAPI呼び出しをする関数のspecを修正 

### DIFF
--- a/spec/models/api/user_spec.rb
+++ b/spec/models/api/user_spec.rb
@@ -10,100 +10,69 @@ RSpec.describe 'User' do
     let(:sort_key) { 'name' }
     let(:order_by) { 'asc' }
     let(:offset) { 0 }
+    let(:current_user) { create(:user, :admin) }
 
-    context 'アクセストークンがない場合' do
-      let(:access_token) { nil }
+    context '不正なクエリパラメータ、アクセストークンが指定された場合' do
+      let(:access_token) { expired_access_token(email: current_user.email) }
 
       before do
         WebMock
           .stub_request(:get, 'http://localhost:3000/api/users')
-          .with(query: { limit:, offset:, order_by:, sort_key: })
+          .with(
+            query:   { limit:, offset:, order_by:, sort_key: },
+            headers: { Authorization: "Bearer #{access_token}" }
+          )
           .to_return(
-            body:    {
+            body:   {
               errors: [
                 {
                   name:    'access_token',
-                  message: 'Authentication token is missing'
+                  message: 'Invalid token'
                 }
               ]
             }.to_json,
-            status:  400,
+            status: 401
+          )
+      end
+
+      it 'ユーザ取得のAPIを呼び、例外を返す' do
+        expect { subject }.to raise_error Api::Error
+        expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
+                             .with(
+                               query:   { limit:, offset:, order_by:, sort_key: },
+                               headers: { Authorization: "Bearer #{access_token}" }
+                             )
+      end
+    end
+
+    context '正当なクエリパラメータ、アクセストークンが指定された場合' do
+      before do
+        WebMock
+          .stub_request(:get, 'http://localhost:3000/api/users')
+          .with(
+            query:   { limit:, offset:, order_by:, sort_key: },
+            headers: { Authorization: "Bearer #{access_token}" }
+          )
+          .to_return(
+            body:    User
+                     .order(sort_key => order_by)
+                     .limit(limit)
+                     .offset(offset).map { |user| user_to_api_user(user) }
+                     .to_json,
+            status:  200,
             headers: { 'Content-Type' => 'application/json' }
           )
       end
 
-      it '例外を投げる' do
-        expect { subject }.to raise_error Api::Error
+      let(:access_token) { AccessToken.new(email: current_user.email).encode }
+
+      it 'ユーザ取得のAPIを呼び、ユーザの配列を返す' do
+        expect(subject).to include Api::User
         expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
-                             .with(query: { limit:, offset:, order_by:, sort_key: })
-      end
-    end
-
-    context 'アクセストークンがある場合' do
-      let(:current_user) { create(:user, :admin) }
-
-      context 'アクセストークンが有効期限切れの場合' do
-        before do
-          WebMock
-            .stub_request(:get, 'http://localhost:3000/api/users')
-            .with(
-              query:   { limit:, offset:, order_by:, sort_key: },
-              headers: { Authorization: "Bearer #{access_token}" }
-            )
-            .to_return(
-              body:   {
-                errors: [
-                  {
-                    name:    'access_token',
-                    message: 'Invalid token'
-                  }
-                ]
-              }.to_json,
-              status: 401
-            )
-        end
-
-        let(:access_token) { expired_access_token(email: current_user.email) }
-
-        it '例外を投げる' do
-          expect { subject }.to raise_error Api::Error
-          expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
-                               .with(
-                                 query:   { limit:, offset:, order_by:, sort_key: },
-                                 headers: { Authorization: "Bearer #{access_token}" }
-                               )
-        end
-      end
-
-      context 'アクセストークンが有効期限内の場合' do
-        before do
-          WebMock
-            .stub_request(:get, 'http://localhost:3000/api/users')
-            .with(
-              query:   { limit:, offset:, order_by:, sort_key: },
-              headers: { Authorization: "Bearer #{access_token}" }
-            )
-            .to_return(
-              body:    User
-                       .order(sort_key => order_by)
-                       .limit(limit)
-                       .offset(offset).map { |user| user_to_api_user(user) }
-                       .to_json,
-              status:  200,
-              headers: { 'Content-Type' => 'application/json' }
-            )
-        end
-
-        let(:access_token) { AccessToken.new(email: current_user.email).encode }
-
-        it 'ユーザの配列が返る' do
-          expect(subject).to include Api::User
-          expect(WebMock).to have_requested(:get, 'http://localhost:3000/api/users')
-                               .with(
-                                 query:   { limit:, offset:, order_by:, sort_key: },
-                                 headers: { Authorization: "Bearer #{access_token}" }
-                               )
-        end
+                             .with(
+                               query:   { limit:, offset:, order_by:, sort_key: },
+                               headers: { Authorization: "Bearer #{access_token}" }
+                             )
       end
     end
   end


### PR DESCRIPTION
## やったこと
ユーザ取得の関数(Api::User.get_list)のspecの修正
 -  `アクセストークンがない場合`を削除した (https://github.com/sls-training/2023-rails-sample/pull/111#discussion_r1237957055)
  - `APIサーバーにアクセスできない場合`を追加した(https://github.com/sls-training/2023-rails-sample/pull/108#discussion_r1238298664 )
