### PR TITLE
トークン生成のAPIのスキーマをcommitteeで確認するように変更(#125の後続)

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -32,7 +32,6 @@ paths:
                   type: string
                   format: password
                   minLength: 6
-              additionalProperties: false
 
       responses:
         '200':

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -38,6 +38,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
                   access_token:
                     type: string

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -32,6 +32,8 @@ paths:
                   type: string
                   format: password
                   minLength: 6
+              additionalProperties: false
+
       responses:
         '200':
           description: 成功した場合
@@ -43,6 +45,7 @@ paths:
                   access_token:
                     type: string
                     example: AAAAAAAAAAAAAAAAAAAAAMLheAAAAAAA0%2BuSeid%2BULvsea4JtiGRiSDSJSI%3DEUifiRBkKG5E2XzMDjRfl76ZC9Ub0wnz4XsNiRVBChTYbJcE3F
+                additionalProperties: false
 
         '401':
           description: 入力を間違えて失敗した場合
@@ -85,3 +88,4 @@ paths:
                           type: string
                           description: エラーのメッセージ
                           example: You are not admin user
+                additionalProperties: false

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -67,6 +67,7 @@ paths:
                           type: string
                           description: エラーのメッセージ
                           example: Incorrect email or password
+                additionalProperties: false
 
         '403':
           description: ユーザに権限がなくて失敗した場合

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
     schema_path:                    Rails.root.join('schema/openapi.yaml').to_s,
     query_hash_key:                 'rack.request.query_hash',
     parse_response_by_content_type: false,
-    strict_reference_validation:    true
+    strict_reference_validation:    true,
+    prefix:                         '/api'
   }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,10 +68,8 @@ RSpec.configure do |config|
   # committee
   config.add_setting :committee_options
   config.committee_options = {
-    schema_path:                    Rails.root.join('schema/openapi.yaml').to_s,
-    query_hash_key:                 'rack.request.query_hash',
-    parse_response_by_content_type: false,
-    strict_reference_validation:    true,
-    prefix:                         '/api'
+    schema_path:                 Rails.root.join('schema/openapi.yaml').to_s,
+    strict_reference_validation: true,
+    prefix:                      '/api'
   }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.after(:suite) { FileUtils.rm_rf(ActiveStorage::Blob.service.root) }
 
   # committee
+  include Committee::Rails::Test::Methods
   config.add_setting :committee_options
   config.committee_options = {
     schema_path:                 Rails.root.join('schema/openapi.yaml').to_s,

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ApiTokens' do
         let(:user) { create(:user, :admin) }
         let(:headers) { { 'Content-Type': 'application/json' } }
 
-        it 'スキーマ通りに200が返って、アクセストークンを返すこと' do
+        it '200が返って、アクセストークンを返すこと' do
           post '/api/token', headers:, params: { email: user.email, password: user.password }, as: :json
           assert_response_schema_confirm(200)
         end
@@ -20,7 +20,7 @@ RSpec.describe 'ApiTokens' do
       context 'ユーザがAdminでない場合' do
         let(:noadmin) { create(:user, :noadmin) }
 
-        it 'スキーマ通りに403が返って、エラーメッセージを返すこと' do
+        it '403が返って、エラーメッセージを返すこと' do
           post '/api/token', headers:, params: { email: noadmin.email, password: noadmin.password }, as: :json
           assert_response_schema_confirm(403)
         end
@@ -28,7 +28,7 @@ RSpec.describe 'ApiTokens' do
     end
 
     context 'ユーザが存在しない場合' do
-      it 'スキーマ通りに401が返って、エラーメッセージを返すこと' do
+      it '401が返って、エラーメッセージを返すこと' do
         post '/api/token', headers:, params: { email: 'test@hogehgoe.com', password: 'invalid password' }, as: :json
         assert_response_schema_confirm(401)
       end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -4,33 +4,35 @@ require 'rails_helper'
 
 RSpec.describe 'ApiTokens' do
   describe 'POST /api/token' do
+    include Committee::Rails::Test::Methods
+
     context 'ユーザが存在する場合' do
       context 'ユーザがadminの場合' do
         let(:user) { create(:user, :admin) }
 
-        it '200が返って、アクセストークンを返すこと' do
+        it 'スキーマ通りに200が返って、アクセストークンを返すこと' do
           post '/api/token', params: { email: user.email, password: user.password }
-          expect(response).to be_successful
           expect(response.parsed_body).to have_key('access_token')
+          assert_response_schema_confirm(200)
         end
       end
 
       context 'ユーザがAdminでない場合' do
         let(:noadmin) { create(:user, :noadmin) }
 
-        it '403が返って、エラーメッセージを返すこと' do
+        it 'スキーマ通りに403が返って、エラーメッセージを返すこと' do
           post '/api/token', params: { email: noadmin.email, password: noadmin.password }
-          expect(response).to have_http_status :forbidden
           expect(response.parsed_body).to have_key('errors')
+          assert_response_schema_confirm(403)
         end
       end
     end
 
     context 'ユーザが存在しない場合' do
-      it '401が返って、エラーメッセージを返すこと' do
+      it 'スキーマ通りに401が返って、エラーメッセージを返すこと' do
         post '/api/token', params: { email: 'test@hogehgoe.com', password: 'invalid password' }
-        expect(response).to have_http_status :unauthorized
         expect(response.parsed_body).to have_key('errors')
+        assert_response_schema_confirm(401)
       end
     end
   end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe 'ApiTokens' do
     context 'ユーザが存在する場合' do
       context 'ユーザがadminの場合' do
         let(:user) { create(:user, :admin) }
+        let(:headers) { { 'Content-Type': 'application/json' } }
 
         it 'スキーマ通りに200が返って、アクセストークンを返すこと' do
-          post '/api/token', params: { email: user.email, password: user.password }
+          post '/api/token', headers:, params: { email: user.email, password: user.password }, as: :json
           expect(response.parsed_body).to have_key('access_token')
           assert_response_schema_confirm(200)
         end
@@ -21,7 +22,7 @@ RSpec.describe 'ApiTokens' do
         let(:noadmin) { create(:user, :noadmin) }
 
         it 'スキーマ通りに403が返って、エラーメッセージを返すこと' do
-          post '/api/token', params: { email: noadmin.email, password: noadmin.password }
+          post '/api/token', headers:, params: { email: noadmin.email, password: noadmin.password }, as: :json
           expect(response.parsed_body).to have_key('errors')
           assert_response_schema_confirm(403)
         end
@@ -30,7 +31,7 @@ RSpec.describe 'ApiTokens' do
 
     context 'ユーザが存在しない場合' do
       it 'スキーマ通りに401が返って、エラーメッセージを返すこと' do
-        post '/api/token', params: { email: 'test@hogehgoe.com', password: 'invalid password' }
+        post '/api/token', headers:, params: { email: 'test@hogehgoe.com', password: 'invalid password' }, as: :json
         expect(response.parsed_body).to have_key('errors')
         assert_response_schema_confirm(401)
       end

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'ApiTokens' do
   describe 'POST /api/token' do
-    include Committee::Rails::Test::Methods
-
     context 'ユーザが存在する場合' do
       context 'ユーザがadminの場合' do
         let(:user) { create(:user, :admin) }

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'ApiTokens' do
 
         it 'スキーマ通りに200が返って、アクセストークンを返すこと' do
           post '/api/token', headers:, params: { email: user.email, password: user.password }, as: :json
-          expect(response.parsed_body).to have_key('access_token')
           assert_response_schema_confirm(200)
         end
       end
@@ -23,7 +22,6 @@ RSpec.describe 'ApiTokens' do
 
         it 'スキーマ通りに403が返って、エラーメッセージを返すこと' do
           post '/api/token', headers:, params: { email: noadmin.email, password: noadmin.password }, as: :json
-          expect(response.parsed_body).to have_key('errors')
           assert_response_schema_confirm(403)
         end
       end
@@ -32,7 +30,6 @@ RSpec.describe 'ApiTokens' do
     context 'ユーザが存在しない場合' do
       it 'スキーマ通りに401が返って、エラーメッセージを返すこと' do
         post '/api/token', headers:, params: { email: 'test@hogehgoe.com', password: 'invalid password' }, as: :json
-        expect(response.parsed_body).to have_key('errors')
         assert_response_schema_confirm(401)
       end
     end


### PR DESCRIPTION
## やったこと
トークン生成のAPIのスキーマをcommitteeで確認するように変更した

レスポンスコードをチェックしていた箇所をそれぞれ`assert_response_schema_confirm("ステータスコード")`に変更した

## わかったこと
- 検証できること
  - OpenApiでスキーマに指定のステータスコードの記載があるのかどうか

- 検証できなかったこと
  - postするbodyのパラメータがあっているかどうか
  - レスポンスのパラメータがあっているかどうか

## 備考
- 今回変更したspecについて、subjectで書かれていなかったが、そこについては今回は考えないこととした

